### PR TITLE
Harden Redis-backed garment type caching

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,4 @@ python-multipart==0.0.9
 SQLAlchemy==2.0.36
 psycopg[binary]==3.2.3
 boto3==1.35.59
+redis==5.1.1


### PR DESCRIPTION
## Summary
- add configurable Redis connection management with startup/shutdown lifecycle, timeouts, and retry backoff for the garment cache
- rewrite garment classification caching to use namespaced SHA256 keys, JSON payloads, TTLs, and single-flight locking with graceful fallback when Redis is unavailable
- document the Redis cache behavior, environment knobs, and source-of-truth expectations in the README

## Test Plan
- python -m compileall backend
- python - <<'PY' ... (simulated Redis outage/auth fallback for _classify_garment_type)


------
https://chatgpt.com/codex/tasks/task_e_68cd655d5fe483338de301e9123de099