### PR TITLE
Deduplicate Gemini helpers

### DIFF
--- a/backend/storage.py
+++ b/backend/storage.py
@@ -39,12 +39,22 @@ def upload_image(png_bytes: bytes, pose: str) -> Tuple[str, str]:
     return AWS_S3_BUCKET, key
 
 
-def upload_source_image(bytes_data: bytes, mime: Optional[str] = None) -> Tuple[str, str]:
-    """Uploads an original source image (any type) into S3 under env_sources/ and returns (bucket, key)."""
+def _upload_bytes(
+    prefix: str,
+    bytes_data: bytes,
+    mime: Optional[str],
+    *,
+    extra_parts: tuple[str, ...] = (),
+) -> Tuple[str, str]:
     if not AWS_S3_BUCKET:
         raise RuntimeError("AWS_S3_BUCKET not configured")
     ext = "png" if (mime == "image/png") else "jpg"
-    key = f"env_sources/{datetime.utcnow().year:04d}/{uuid.uuid4().hex}.{ext}"
+    today = datetime.utcnow()
+    cleaned_parts = [prefix.strip("/")]
+    cleaned_parts.extend(part.strip("/") for part in extra_parts if part)
+    cleaned_parts.append(f"{today.year:04d}")
+    cleaned_parts.append(f"{uuid.uuid4().hex}.{ext}")
+    key = "/".join(cleaned_parts)
     get_s3().put_object(
         Bucket=AWS_S3_BUCKET,
         Key=key,
@@ -54,40 +64,21 @@ def upload_source_image(bytes_data: bytes, mime: Optional[str] = None) -> Tuple[
         ACL="private",
     )
     return AWS_S3_BUCKET, key
+
+
+def upload_source_image(bytes_data: bytes, mime: Optional[str] = None) -> Tuple[str, str]:
+    """Uploads an original source image (any type) into S3 under env_sources/ and returns (bucket, key)."""
+    return _upload_bytes("env_sources", bytes_data, mime)
 
 
 def upload_pose_source_image(bytes_data: bytes, mime: Optional[str] = None) -> Tuple[str, str]:
     """Uploads a pose source image to S3 under pose_sources/ and returns (bucket, key)."""
-    if not AWS_S3_BUCKET:
-        raise RuntimeError("AWS_S3_BUCKET not configured")
-    ext = "png" if (mime == "image/png") else "jpg"
-    key = f"pose_sources/{datetime.utcnow().year:04d}/{uuid.uuid4().hex}.{ext}"
-    get_s3().put_object(
-        Bucket=AWS_S3_BUCKET,
-        Key=key,
-        Body=bytes_data,
-        ContentType=mime or "application/octet-stream",
-        CacheControl="public, max-age=31536000, immutable",
-        ACL="private",
-    )
-    return AWS_S3_BUCKET, key
+    return _upload_bytes("pose_sources", bytes_data, mime)
 
 
 def upload_model_source_image(bytes_data: bytes, gender: str, mime: Optional[str] = None) -> Tuple[str, str]:
     """Uploads a model source image to S3 under model_sources/<gender>/ and returns (bucket, key)."""
-    if not AWS_S3_BUCKET:
-        raise RuntimeError("AWS_S3_BUCKET not configured")
-    ext = "png" if (mime == "image/png") else "jpg"
-    key = f"model_sources/{gender}/{datetime.utcnow().year:04d}/{uuid.uuid4().hex}.{ext}"
-    get_s3().put_object(
-        Bucket=AWS_S3_BUCKET,
-        Key=key,
-        Body=bytes_data,
-        ContentType=mime or "application/octet-stream",
-        CacheControl="public, max-age=31536000, immutable",
-        ACL="private",
-    )
-    return AWS_S3_BUCKET, key
+    return _upload_bytes("model_sources", bytes_data, mime, extra_parts=(gender,))
 
 
 def get_object_bytes(key: str) -> Tuple[bytes, str]:
@@ -101,19 +92,7 @@ def get_object_bytes(key: str) -> Tuple[bytes, str]:
 
 def upload_product_source_image(bytes_data: bytes, mime: Optional[str] = None) -> Tuple[str, str]:
     """Uploads a garment/product source image to S3 under product_sources/ and returns (bucket, key)."""
-    if not AWS_S3_BUCKET:
-        raise RuntimeError("AWS_S3_BUCKET not configured")
-    ext = "png" if (mime == "image/png") else "jpg"
-    key = f"product_sources/{datetime.utcnow().year:04d}/{uuid.uuid4().hex}.{ext}"
-    get_s3().put_object(
-        Bucket=AWS_S3_BUCKET,
-        Key=key,
-        Body=bytes_data,
-        ContentType=mime or "application/octet-stream",
-        CacheControl="public, max-age=31536000, immutable",
-        ACL="private",
-    )
-    return AWS_S3_BUCKET, key
+    return _upload_bytes("product_sources", bytes_data, mime)
 
 
 def delete_objects(keys: List[str]) -> None:


### PR DESCRIPTION
## Summary
- add a reusable helper to grab inline image data from Gemini responses and switch endpoints to use it
- factor the shared /env/random and /env/generate flow into a coroutine
- unify the duplicate S3 upload helpers behind a single uploader

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68cd9a6d33e88333895dd9c29b114245