### PR TITLE
Refactor listing page into hook-driven components

### DIFF
--- a/app/components/admin-review-panel.js
+++ b/app/components/admin-review-panel.js
@@ -1,0 +1,38 @@
+"use client";
+
+import { PromptPreviewCard } from "./prompt-preview-card";
+import { PoseStatusList } from "./pose-status-list";
+
+export function AdminReviewPanel({
+  gender,
+  environmentSummary,
+  poseSummary,
+  modelSummary,
+  flowMode,
+  garmentSummary,
+  prompt,
+  promptDirty,
+  onPromptChange,
+  onPromptReset,
+  poseStatusItems,
+}) {
+  return (
+    <div className="space-y-4 rounded-2xl border border-black/10 bg-black/5 p-4 dark:border-white/15 dark:bg-white/5 sm:p-6">
+      <div className="flex flex-wrap items-center gap-2 text-xs">
+        <span className="rounded-full border border-foreground/15 px-3 py-1">{gender}</span>
+        <span className="rounded-full border border-foreground/15 px-3 py-1">Env: {environmentSummary}</span>
+        <span className="rounded-full border border-foreground/15 px-3 py-1">Poses: {poseSummary || "–"}</span>
+        <span className="rounded-full border border-foreground/15 px-3 py-1">Model: {modelSummary}</span>
+        <span className="rounded-full border border-foreground/15 px-3 py-1">Flow: {flowMode}</span>
+        <span className="rounded-full border border-foreground/15 px-3 py-1">Type: {garmentSummary}</span>
+      </div>
+      <PromptPreviewCard
+        prompt={prompt}
+        dirty={promptDirty}
+        onChange={onPromptChange}
+        onReset={onPromptReset}
+      />
+      <PoseStatusList items={poseStatusItems} />
+    </div>
+  );
+}

--- a/app/components/admin-tools-card.js
+++ b/app/components/admin-tools-card.js
@@ -1,0 +1,28 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+
+export function AdminToolsCard({ busy, onInitDb }) {
+  return (
+    <div className="rounded-2xl border border-black/10 bg-black/5 p-4 text-sm dark:border-white/15 dark:bg-white/5">
+      <h2 className="text-sm font-semibold">Admin tools</h2>
+      <button
+        type="button"
+        onClick={onInitDb}
+        disabled={busy}
+        className={`mt-3 inline-flex w-full items-center justify-center gap-2 rounded-lg border px-3 py-2 text-xs font-semibold ${
+          busy ? "opacity-60" : ""
+        }`}
+      >
+        {busy ? (
+          <>
+            <Loader2 className="size-3 animate-spin" />
+            Initializing…
+          </>
+        ) : (
+          <>Init DB</>
+        )}
+      </button>
+    </div>
+  );
+}

--- a/app/components/description-settings.js
+++ b/app/components/description-settings.js
@@ -1,0 +1,81 @@
+"use client";
+
+const CONDITIONS = ["Brand new", "Very good", "Good"];
+const SIZES = ["xs", "s", "m", "l", "xl"];
+
+export function DescriptionSettings({
+  enabled,
+  onToggle,
+  desc,
+  onDescFieldChange,
+  productCondition,
+  onConditionChange,
+}) {
+  return (
+    <div className="mt-4 space-y-3 rounded-xl border border-foreground/15 bg-background/40 p-4">
+      <div className="flex items-center justify-between text-xs text-foreground/70">
+        <span>Generate product description</span>
+        <button
+          type="button"
+          onClick={() => onToggle(!enabled)}
+          className={`relative inline-flex h-6 w-12 items-center rounded-full transition ${
+            enabled ? "bg-foreground" : "bg-foreground/30"
+          }`}
+          aria-pressed={enabled}
+        >
+          <span
+            className={`inline-block h-5 w-5 transform rounded-full bg-background transition ${
+              enabled ? "translate-x-6" : "translate-x-1"
+            }`}
+          />
+        </button>
+      </div>
+      {enabled && (
+        <div className="grid grid-cols-2 gap-2 text-sm">
+          <input
+            type="text"
+            className="col-span-2 h-9 rounded-lg border border-foreground/15 bg-background/40 px-3"
+            placeholder="Brand (e.g., Nike, Zara)"
+            value={desc.brand}
+            onChange={(e) => onDescFieldChange("brand", e.target.value)}
+          />
+          <input
+            type="text"
+            className="col-span-2 h-9 rounded-lg border border-foreground/15 bg-background/40 px-3"
+            placeholder="Model (e.g., Air Max 90)"
+            value={desc.productModel}
+            onChange={(e) => onDescFieldChange("productModel", e.target.value)}
+          />
+          <div className="col-span-2 flex flex-wrap gap-2">
+            {CONDITIONS.map((condition) => (
+              <button
+                key={condition}
+                type="button"
+                onClick={() => onConditionChange(condition)}
+                className={`h-8 rounded-full border px-3 text-xs ${
+                  productCondition === condition ? "border-foreground" : "border-foreground/20"
+                }`}
+              >
+                {condition}
+              </button>
+            ))}
+          </div>
+          <div className="col-span-2 flex flex-wrap gap-2">
+            {SIZES.map((size) => (
+              <button
+                key={size}
+                type="button"
+                onClick={() => onDescFieldChange("size", size)}
+                className={`h-8 rounded-full border px-3 text-xs uppercase ${
+                  desc.size === size ? "border-foreground" : "border-foreground/20"
+                }`}
+              >
+                {size}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/garment-type-selector.js
+++ b/app/components/garment-type-selector.js
@@ -1,0 +1,34 @@
+"use client";
+
+import { InfoTooltip } from "./info-tooltip";
+
+const TYPES = ["top", "bottom", "full"];
+
+export function GarmentTypeSelector({ value, onChange }) {
+  return (
+    <div className="mt-4">
+      <label className="inline-flex items-center gap-2 text-xs font-medium text-foreground/80">
+        Garment type
+        <InfoTooltip
+          label="Garment type"
+          description="Set to Top/Bottom/Full if you know it. Leave empty to auto-detect once and cache on the listing."
+        />
+      </label>
+      <div className="mt-2 grid grid-cols-3 overflow-hidden rounded-lg border border-foreground/15">
+        {TYPES.map((t) => (
+          <button
+            key={t}
+            type="button"
+            onClick={() => onChange(value === t ? null : t)}
+            className={`h-10 text-xs font-medium uppercase tracking-wide transition ${
+              value === t ? "bg-foreground text-background" : "text-foreground/70"
+            }`}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+      {!value && <p className="mt-1 text-[11px] text-foreground/50">Auto-detect if not set.</p>}
+    </div>
+  );
+}

--- a/app/components/index.js
+++ b/app/components/index.js
@@ -1,3 +1,10 @@
-export { OptionPicker } from "./option-picker";
-export { PromptPreviewCard } from "./prompt-preview-card";
+export { AdminReviewPanel } from "./admin-review-panel";
+export { AdminToolsCard } from "./admin-tools-card";
+export { DescriptionSettings } from "./description-settings";
+export { GarmentTypeSelector } from "./garment-type-selector";
 export { InfoTooltip } from "./info-tooltip";
+export { OptionPicker } from "./option-picker";
+export { PoseStatusList } from "./pose-status-list";
+export { PromptPreviewCard } from "./prompt-preview-card";
+export { SceneModelOptions } from "./scene-model-options";
+export { UploadPanel } from "./upload-panel";

--- a/app/components/pose-status-list.js
+++ b/app/components/pose-status-list.js
@@ -1,0 +1,36 @@
+"use client";
+
+export function PoseStatusList({ items }) {
+  if (!items || items.length === 0) return null;
+
+  const resolveStatusLabel = (status, error) => {
+    if (status === "running") return "Generating…";
+    if (status === "done") return "Ready";
+    if (status === "error") return error || "Failed";
+    return "Queued";
+  };
+
+  return (
+    <div className="rounded-xl border border-foreground/10 bg-background/40 p-4">
+      <h3 className="text-sm font-semibold">Generation status</h3>
+      <ul className="mt-2 space-y-2 text-xs">
+        {items.map(({ key, label, status, error }) => (
+          <li key={key} className="flex items-start justify-between gap-3">
+            <span className="font-medium">{label}</span>
+            <span
+              className={
+                status === "error"
+                  ? "text-red-500"
+                  : status === "done"
+                    ? "text-green-400"
+                    : "text-foreground/60"
+              }
+            >
+              {resolveStatusLabel(status, error)}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/components/scene-model-options.js
+++ b/app/components/scene-model-options.js
@@ -1,0 +1,241 @@
+"use client";
+
+import Link from "next/link";
+import Image from "next/image";
+import { ImageOff } from "lucide-react";
+
+import { OptionPicker } from "./option-picker";
+
+export function SceneModelOptions({
+  collapsed,
+  onToggleCollapsed,
+  modelDefaultList,
+  selectedGender,
+  onSelectGender,
+  modelDefaults,
+  isAdmin,
+  useModelImage,
+  onUseModelImageChange,
+  modelReferenceOptions,
+  flowOptions,
+  flowMode,
+  onFlowModeChange,
+  envDefaults,
+  envDefaultsLoading,
+  selectedEnvDefaultKey,
+  onSelectEnvironmentDefault,
+  environmentOptions,
+  onEnvironmentChange,
+  environmentValue,
+  plannedImagesCount,
+  poseMax,
+  onPoseCountChange,
+  extraInstructions,
+  onExtraChange,
+}) {
+  const selectedModelDefault = selectedGender === "woman" ? modelDefaults?.woman : modelDefaults?.man;
+  const showDescriptionWarning = !useModelImage && !selectedModelDefault?.description;
+
+  return (
+    <div className="rounded-2xl border border-black/10 bg-black/5 dark:border-white/15 dark:bg-white/5">
+      <button
+        type="button"
+        onClick={onToggleCollapsed}
+        className="flex w-full items-center justify-between gap-3 px-4 py-3 text-left text-sm font-semibold"
+      >
+        <span>Scene & model options</span>
+        <span className="text-xs text-foreground/60">{collapsed ? "Show" : "Hide"}</span>
+      </button>
+      {!collapsed && (
+        <div className="border-t border-foreground/10 px-4 py-5">
+          <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
+            <div className="sm:col-span-2">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <p className="text-sm font-semibold">Model defaults</p>
+                  <p className="mt-1 text-xs text-foreground/60">Pick a Studio default image to set the person and gender.</p>
+                </div>
+                <Link href="/studio" className="text-xs text-foreground/60 underline">
+                  Manage
+                </Link>
+              </div>
+              {modelDefaultList.length > 0 ? (
+                <div className="mt-3 flex gap-3 overflow-x-auto pb-1">
+                  {modelDefaultList.map((model) => {
+                    const selected = selectedGender === model.gender;
+                    const genderLabel = model.gender === "woman" ? "Woman" : "Man";
+                    return (
+                      <button
+                        key={model.gender}
+                        type="button"
+                        onClick={() => onSelectGender(model.gender)}
+                        className={`group w-32 flex-shrink-0 overflow-hidden rounded-xl border text-left transition ${
+                          selected
+                            ? "border-foreground ring-2 ring-foreground/40 bg-foreground/5 shadow-lg"
+                            : "border-foreground/15 hover:border-foreground/50"
+                        }`}
+                        aria-pressed={selected}
+                      >
+                        <div className="relative aspect-[3/4] w-full overflow-hidden">
+                          {model.url ? (
+                            <Image
+                              src={model.url}
+                              alt={`${genderLabel} default`}
+                              fill
+                              sizes="128px"
+                              className="object-cover transition duration-300 group-hover:scale-[1.02]"
+                              unoptimized
+                            />
+                          ) : (
+                            <div className="flex h-full w-full items-center justify-center bg-foreground/10 text-foreground/50">
+                              <ImageOff className="size-6" aria-hidden="true" />
+                            </div>
+                          )}
+                        </div>
+                        <div className="px-3 py-2">
+                          <p className="text-sm font-semibold capitalize">{model.name || genderLabel}</p>
+                          <p className="text-[11px] text-foreground/60">{genderLabel} fit</p>
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              ) : (
+                <div className="mt-3 rounded-lg border border-foreground/15 bg-background/40 p-3 text-xs text-foreground/60">
+                  No Studio defaults yet. <Link href="/studio" className="underline">Add one</Link> to unlock a quicker flow.
+                </div>
+              )}
+            </div>
+            {isAdmin && (
+              <div className="sm:col-span-2">
+                <OptionPicker
+                  label="Model reference"
+                  description="Use your default model photo from Studio, or send its description only."
+                  options={modelReferenceOptions}
+                  value={useModelImage ? "image" : "description"}
+                  onChange={(value) => onUseModelImageChange(value === "image")}
+                />
+                {showDescriptionWarning && (
+                  <p className="mt-1 text-[11px] text-amber-500">No default description stored yet. Add one from Studio.</p>
+                )}
+              </div>
+            )}
+            {isAdmin && (
+              <div className="sm:col-span-2">
+                <OptionPicker label="Generation flow" options={flowOptions} value={flowMode} onChange={onFlowModeChange} />
+              </div>
+            )}
+            <div className="sm:col-span-2">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <p className="text-sm font-semibold">Environment defaults</p>
+                  <p className="mt-1 text-xs text-foreground/60">Pick from your saved backgrounds. Add more in Studio to build a library.</p>
+                </div>
+                <Link href="/studio" className="text-xs text-foreground/60 underline">
+                  Manage
+                </Link>
+              </div>
+              {envDefaultsLoading ? (
+                <div className="mt-3 flex gap-3 overflow-x-auto pb-1">
+                  {Array.from({ length: 4 }).map((_, i) => (
+                    <div key={i} className="h-32 w-32 flex-shrink-0 animate-pulse rounded-xl bg-foreground/10" />
+                  ))}
+                </div>
+              ) : envDefaults.length > 0 ? (
+                <div className="mt-3 flex gap-3 overflow-x-auto pb-1">
+                  {envDefaults.map((env) => {
+                    const selected = selectedEnvDefaultKey === env.s3_key;
+                    return (
+                      <button
+                        key={env.s3_key}
+                        type="button"
+                        onClick={() => onSelectEnvironmentDefault(env.s3_key)}
+                        className={`group w-32 flex-shrink-0 overflow-hidden rounded-xl border text-left transition ${
+                          selected
+                            ? "border-foreground ring-2 ring-foreground/40 bg-foreground/5 shadow-lg"
+                            : "border-foreground/15 hover:border-foreground/50"
+                        }`}
+                        aria-pressed={selected}
+                      >
+                        <div className="relative aspect-[3/4] w-full overflow-hidden">
+                          {env.url ? (
+                            <Image
+                              src={env.url}
+                              alt={env.name || "Environment"}
+                              fill
+                              sizes="128px"
+                              className="object-cover transition duration-300 group-hover:scale-[1.02]"
+                              unoptimized
+                            />
+                          ) : (
+                            <div className="flex h-full w-full items-center justify-center bg-foreground/10 text-foreground/50">
+                              <ImageOff className="size-6" aria-hidden="true" />
+                            </div>
+                          )}
+                        </div>
+                        <div className="px-3 py-2">
+                          <p className="text-sm font-semibold">{env.name || "Untitled"}</p>
+                          <p className="text-[11px] text-foreground/60">{selected ? "Current selection" : "Tap to select"}</p>
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              ) : (
+                <div className="mt-3 space-y-3">
+                  <OptionPicker options={environmentOptions} value={environmentValue} onChange={onEnvironmentChange} />
+                  <p className="text-[11px] text-foreground/50">Save environment photos in Studio to see them here.</p>
+                </div>
+              )}
+            </div>
+            <div className="sm:col-span-2">
+              <div className="rounded-2xl border border-foreground/15 bg-background/60 p-4 shadow-sm">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold">Image count</p>
+                    <p className="mt-1 text-xs text-foreground/60">Pick how many images to generate (max {poseMax}).</p>
+                  </div>
+                  <div className="inline-flex items-baseline gap-2 rounded-xl bg-foreground px-4 py-2 text-background shadow">
+                    <span className="text-2xl font-semibold leading-none">{plannedImagesCount}</span>
+                    <span className="text-[11px] uppercase tracking-wide text-background/70">images</span>
+                  </div>
+                </div>
+                <div className="mt-4 grid grid-cols-5 gap-2">
+                  {Array.from({ length: poseMax }, (_, idx) => idx + 1).map((count) => {
+                    const checked = plannedImagesCount === count;
+                    return (
+                      <button
+                        key={count}
+                        type="button"
+                        onClick={() => onPoseCountChange(count)}
+                        className={`group flex h-10 items-center justify-center rounded-lg border text-sm font-semibold transition ${
+                          checked
+                            ? "border-foreground bg-foreground text-background shadow"
+                            : "border-foreground/20 bg-background/80 text-foreground/70 hover:border-foreground/60 hover:text-foreground"
+                        }`}
+                        aria-pressed={checked}
+                      >
+                        {count}
+                      </button>
+                    );
+                  })}
+                </div>
+                <p className="mt-3 text-[11px] text-foreground/60">We’ll pick varied poses automatically for each image.</p>
+              </div>
+            </div>
+            <div className="sm:col-span-2">
+              <label className="text-xs text-foreground/70">Extra instructions</label>
+              <textarea
+                rows={3}
+                className="mt-2 w-full rounded-lg border border-foreground/15 bg-background/40 px-3 py-2 text-sm"
+                placeholder="Optional: add a style tweak, colours, or vibe"
+                value={extraInstructions}
+                onChange={(e) => onExtraChange(e.target.value)}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/upload-panel.js
+++ b/app/components/upload-panel.js
@@ -1,0 +1,105 @@
+"use client";
+
+import { Camera } from "lucide-react";
+
+export function UploadPanel({
+  fileInputRef,
+  cameraInputRef,
+  previewUrl,
+  selectedFile,
+  isDragging,
+  isPreprocessing,
+  plannedImagesCount,
+  title,
+  onTitleChange,
+  onTriggerPick,
+  onTriggerCamera,
+  onFileChange,
+  onDrop,
+  onDragOver,
+  onDragLeave,
+  onClearSelection,
+}) {
+  return (
+    <div className="rounded-2xl border border-black/10 bg-black/5 p-4 dark:border-white/15 dark:bg-white/5 sm:p-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold">Upload garment</h2>
+          <p className="text-xs text-foreground/60">Drop a clear photo of the item you want the model to wear.</p>
+        </div>
+        <div className="flex items-center gap-2 text-sm">
+          <button
+            type="button"
+            onClick={onTriggerCamera}
+            className="inline-flex items-center gap-2 rounded-full border border-foreground/20 px-3 py-1.5 font-semibold text-foreground transition hover:border-foreground/40"
+          >
+            <Camera className="size-4" aria-hidden="true" />
+            <span>Take photo</span>
+          </button>
+        </div>
+      </div>
+      <div className="mt-4">
+        <input ref={fileInputRef} type="file" accept="image/*" className="hidden" onChange={onFileChange} />
+        <input ref={cameraInputRef} type="file" accept="image/*" capture="environment" className="hidden" onChange={onFileChange} />
+        {!previewUrl ? (
+          <button
+            type="button"
+            onClick={onTriggerPick}
+            onDrop={onDrop}
+            onDragOver={onDragOver}
+            onDragLeave={onDragLeave}
+            className={`flex aspect-[4/5] w-full items-center justify-center rounded-xl border border-dashed px-4 text-center transition-colors ${
+              isDragging ? "border-blue-500 bg-blue-500/10" : "border-foreground/20 hover:border-foreground/40"
+            }`}
+          >
+            <div className="flex flex-col items-center gap-2 text-foreground/70">
+              <div className="size-14 rounded-full border border-dashed border-current/30 flex items-center justify-center">
+                <Camera className="size-6" />
+              </div>
+              <div className="text-sm">
+                <span className="font-medium text-foreground">Tap to upload</span> or drop an image
+              </div>
+              <div className="text-xs">PNG, JPG, HEIC up to ~10MB</div>
+              {isPreprocessing && <div className="mt-1 text-xs">Optimizing photo…</div>}
+            </div>
+          </button>
+        ) : (
+          <div className="w-full overflow-hidden rounded-xl border border-foreground/15 bg-background/40">
+            <div className="relative w-full aspect-[4/5]">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={previewUrl} alt="Selected garment" className="h-full w-full object-cover" />
+              {isPreprocessing && (
+                <div className="absolute bottom-2 right-2 rounded-md border border-black/10 bg-background/80 px-2 py-1 text-[11px] dark:border-white/15">
+                  Optimizing…
+                </div>
+              )}
+              <div className="absolute top-2 right-2 rounded-md border border-black/10 bg-background/80 px-2 py-1 text-[11px] dark:border-white/15">
+                {plannedImagesCount} image{plannedImagesCount > 1 ? "s" : ""}
+              </div>
+            </div>
+            <div className="flex flex-wrap items-center justify-between gap-3 border-t border-foreground/10 p-3 text-sm">
+              <div className="min-w-0">
+                <p className="truncate font-medium">{selectedFile?.name || "Selected image"}</p>
+                <p className="text-xs text-foreground/60">{selectedFile?.size ? `${Math.round(selectedFile.size / 1024)} KB` : ""}</p>
+              </div>
+              <div className="flex items-center gap-2">
+                <button type="button" onClick={onTriggerPick} className="h-9 rounded-lg bg-foreground px-3 text-sm font-medium text-background">Change</button>
+                <button type="button" onClick={onClearSelection} className="h-9 rounded-lg border border-foreground/20 px-3 text-sm font-medium">Remove</button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+      <div className="mt-4">
+        <label className="text-xs text-foreground/70">Listing title</label>
+        <input
+          type="text"
+          placeholder="Give this generation a name"
+          className="mt-2 h-10 w-full rounded-lg border border-foreground/15 bg-background/40 px-3 text-sm"
+          value={title}
+          onChange={(e) => onTitleChange(e.target.value)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/hooks/use-listing-generator.js
+++ b/app/hooks/use-listing-generator.js
@@ -1,0 +1,243 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { toast } from "react-hot-toast";
+
+import { getApiBase, withUserId } from "@/app/lib/api";
+import { broadcastListingsUpdated } from "@/app/lib/listings-events";
+
+export function useListingGenerator({
+  selectedFile,
+  options,
+  plannedImagesCount,
+  selectedEnvDefaultKey,
+  envDefaults,
+  modelDefaults,
+  useModelImage,
+  promptDirty,
+  promptInput,
+  garmentType,
+  title,
+  descEnabled,
+  desc,
+  productCondition,
+  userId,
+  flowMode,
+  resolvePoseInstruction,
+  computeEffectivePrompt,
+}) {
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [poseStatus, setPoseStatus] = useState({});
+  const [poseErrors, setPoseErrors] = useState({});
+
+  const handleGenerate = useCallback(async () => {
+    if (!selectedFile) return;
+
+    try {
+      setIsGenerating(true);
+      const baseUrl = getApiBase();
+
+      const imageCount = plannedImagesCount;
+      const poseSlots = Array.from({ length: imageCount }, (_, idx) => ({ key: `slot-${idx + 1}`, index: idx }));
+
+      const envDefaultKey = options.environment === "studio" && (selectedEnvDefaultKey || envDefaults[0]?.s3_key)
+        ? (selectedEnvDefaultKey || envDefaults[0]?.s3_key)
+        : undefined;
+
+      const lform = new FormData();
+      lform.append("image", selectedFile);
+      lform.append("gender", options.gender);
+      lform.append("environment", options.environment);
+      for (const slot of poseSlots) {
+        const { description } = resolvePoseInstruction(slot.index);
+        const snapshot = description || "random pose";
+        lform.append("poses", snapshot);
+      }
+      lform.append("extra", options.extra || "");
+      if (envDefaultKey) lform.append("env_default_s3_key", envDefaultKey);
+      const personDefault = options.gender === "woman" ? modelDefaults?.woman : modelDefaults?.man;
+      const personDefaultKey = personDefault?.s3_key;
+      const personDesc = personDefault?.description;
+      if (useModelImage && personDefaultKey) lform.append("model_default_s3_key", personDefaultKey);
+      if (!useModelImage && personDesc) lform.append("model_description_text", personDesc);
+      lform.append("use_model_image", String(!!useModelImage));
+      if (promptDirty) lform.append("prompt_override", promptInput.trim());
+      if (garmentType) lform.append("garment_type_override", garmentType);
+      if (title) lform.append("title", title);
+      const toastId = toast.loading("Creating listing…");
+      const lres = await fetch(`${baseUrl}/listing`, { method: "POST", body: lform, headers: withUserId({}, userId) });
+      if (!lres.ok) throw new Error(await lres.text());
+      const listing = await lres.json();
+      const listingId = listing?.id;
+      if (!listingId) throw new Error("No listing id");
+      broadcastListingsUpdated();
+
+      let done = 0;
+      toast.loading(`Generating images ${done}/${poseSlots.length}…`, { id: toastId });
+      const initialStatus = {};
+      for (const slot of poseSlots) initialStatus[slot.key] = "running";
+      setPoseStatus(initialStatus);
+      setPoseErrors({});
+
+      const limit = (n, fns) => new Promise((resolve) => {
+        const out = new Array(fns.length);
+        let i = 0;
+        let running = 0;
+        let finished = 0;
+        const next = () => {
+          if (finished >= fns.length) return resolve(out);
+          while (running < n && i < fns.length) {
+            const idx = i;
+            i += 1;
+            running += 1;
+            fns[idx]()
+              .then((v) => { out[idx] = { status: "fulfilled", value: v }; })
+              .catch((e) => { out[idx] = { status: "rejected", reason: e }; })
+              .finally(() => {
+                running -= 1;
+                finished += 1;
+                next();
+              });
+          }
+        };
+        next();
+      });
+
+      const buildCommonForm = (slotIndex) => {
+        const form = new FormData();
+        form.append("image", selectedFile);
+        form.append("gender", options.gender);
+        form.append("environment", options.environment);
+        form.append("poses", "standing");
+        form.append("extra", options.extra || "");
+        if (envDefaultKey) form.append("env_default_s3_key", envDefaultKey);
+        if (useModelImage && personDefaultKey) form.append("model_default_s3_key", personDefaultKey);
+        else if (!useModelImage && personDesc) form.append("model_description_text", personDesc);
+        form.append("listing_id", listingId);
+        if (garmentType) form.append("garment_type_override", garmentType);
+        return form;
+      };
+
+      const cloneForm = (fd) => {
+        const f = new FormData();
+        fd.forEach((value, key) => {
+          f.append(key, value);
+        });
+        return f;
+      };
+
+      const buildPrompt = (slotIndex) => {
+        if (promptDirty) {
+          let effective = promptInput.trim();
+          const { description } = resolvePoseInstruction(slotIndex);
+          if (description) effective += `\nPose description: ${description}`;
+          return effective;
+        }
+        return computeEffectivePrompt(slotIndex, false);
+      };
+
+      const runPose = ({ key, index: slotIndex }) => async () => {
+        const common = buildCommonForm(slotIndex);
+        const prompt = buildPrompt(slotIndex);
+        const classicReq = async () => {
+          const f = cloneForm(common);
+          f.append("prompt_override", prompt);
+          const res = await fetch(`${baseUrl}/edit/json`, { method: "POST", body: f, headers: withUserId({}, userId) });
+          if (!res.ok) throw new Error(await res.text());
+          return res.json();
+        };
+        const seqReq = async () => {
+          const f = cloneForm(common);
+          const res = await fetch(`${baseUrl}/edit/sequential/json`, { method: "POST", body: f, headers: withUserId({}, userId) });
+          if (!res.ok) throw new Error(await res.text());
+          return res.json();
+        };
+        let classicP = null;
+        let seqP = null;
+        if (flowMode === "classic") classicP = classicReq();
+        else if (flowMode === "sequential") seqP = seqReq();
+        else {
+          classicP = classicReq();
+          seqP = seqReq();
+        }
+        let firstDone = false;
+        const markDone = () => {
+          if (!firstDone) {
+            firstDone = true;
+            done += 1;
+            toast.loading(`Generating images ${done}/${poseSlots.length}…`, { id: toastId });
+            setPoseStatus((s) => ({ ...s, [key]: "done" }));
+          }
+        };
+        if (classicP) classicP.then(() => markDone()).catch(() => {});
+        if (seqP) seqP.then(() => markDone()).catch(() => {});
+        const results = await Promise.all(
+          [classicP, seqP]
+            .filter(Boolean)
+            .map((p) => p.then((v) => ({ ok: true, v })).catch((e) => ({ ok: false, e })))
+        );
+        const ok = results.find((r) => r.ok);
+        if (ok) {
+          return ok.v;
+        }
+        setPoseStatus((s) => ({ ...s, [key]: "error" }));
+        setPoseErrors((e) => ({ ...e, [key]: results.map((r) => r.e?.message || "Failed").join("; ") }));
+        throw new Error(`Pose ${slotIndex + 1} failed`);
+      };
+
+      const tasks = poseSlots.map((slot) => runPose(slot));
+      const settled = await limit(2, tasks);
+      const okAny = settled.some((r) => r && r.status === "fulfilled");
+      if (!okAny) throw new Error("All generations failed");
+
+      if (descEnabled) {
+        try {
+          const dform = new FormData();
+          dform.append("image", selectedFile);
+          dform.append("gender", options.gender);
+          if (desc.brand) dform.append("brand", desc.brand);
+          if (desc.productModel) dform.append("model_name", desc.productModel);
+          if (desc.size) dform.append("size", desc.size);
+          if (productCondition) dform.append("condition", productCondition);
+          dform.append("listing_id", listingId);
+          toast.loading("Generating description…", { id: toastId });
+          await fetch(`${baseUrl}/describe`, { method: "POST", body: dform, headers: withUserId({}, userId) });
+        } catch {}
+      }
+
+      toast.success("Listing ready!", { id: toastId });
+      window.location.href = `/listing/${listingId}`;
+    } catch (err) {
+      console.error(err);
+      toast.error("Generation failed. Check backend/API key.");
+    } finally {
+      setIsGenerating(false);
+    }
+  }, [
+    selectedFile,
+    plannedImagesCount,
+    options,
+    selectedEnvDefaultKey,
+    envDefaults,
+    modelDefaults,
+    useModelImage,
+    promptDirty,
+    promptInput,
+    garmentType,
+    title,
+    descEnabled,
+    desc,
+    productCondition,
+    userId,
+    flowMode,
+    resolvePoseInstruction,
+    computeEffectivePrompt,
+  ]);
+
+  return {
+    isGenerating,
+    poseStatus,
+    poseErrors,
+    handleGenerate,
+  };
+}


### PR DESCRIPTION
## Summary
- extract listing generation workflow into a reusable `useListingGenerator` hook for managing async flow and status updates
- factor major UI sections (upload panel, description controls, scene options, admin review/tools) into dedicated components under `app/components`
- simplify `app/page.js` to compose the new hook and components while keeping existing state and behaviors intact

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cda7fed6788333a881990959b6b076