### PR TITLE
Refactor session basics helper

### DIFF
--- a/app/lib/session.js
+++ b/app/lib/session.js
@@ -1,0 +1,10 @@
+export function getSessionBasics(session) {
+  const userId =
+    session?.session?.userId ||
+    session?.user?.id ||
+    session?.user?.email ||
+    null;
+  const isAdmin = Boolean(session?.user?.isAdmin);
+  return { userId, isAdmin };
+}
+

--- a/app/listing/[id]/page.js
+++ b/app/listing/[id]/page.js
@@ -8,6 +8,7 @@ import { toast } from "react-hot-toast";
 import { createAuthClient } from "better-auth/react";
 import { ChevronLeft, ChevronRight, Maximize2, X as XIcon } from "lucide-react";
 import { getApiBase, withUserId } from "@/app/lib/api";
+import { getSessionBasics } from "@/app/lib/session";
 import { broadcastListingsUpdated } from "@/app/lib/listings-events";
 
 const authClient = createAuthClient();
@@ -16,7 +17,7 @@ export default function ListingPage() {
   const params = useParams();
   const id = Array.isArray(params?.id) ? params.id[0] : params?.id;
   const { data: session } = authClient.useSession();
-  const userId = session?.session?.userId || session?.user?.id || session?.user?.email || null;
+  const { userId } = getSessionBasics(session);
 
   const [listing, setListing] = useState(null);
   const [loading, setLoading] = useState(true);

--- a/app/listings/page.js
+++ b/app/listings/page.js
@@ -6,14 +6,14 @@ import Image from "next/image";
 import { createAuthClient } from "better-auth/react";
 import { Plus } from "lucide-react";
 import { getApiBase, withUserId } from "@/app/lib/api";
+import { getSessionBasics } from "@/app/lib/session";
 import { subscribeToListingsUpdates } from "@/app/lib/listings-events";
 
 const authClient = createAuthClient();
 
 export default function ListingsPage() {
   const { data: session } = authClient.useSession();
-  const userId = session?.session?.userId || session?.user?.id || session?.user?.email || null;
-  const isAdmin = Boolean(session?.user?.isAdmin);
+  const { userId, isAdmin } = getSessionBasics(session);
   const [listings, setListings] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);

--- a/app/page.js
+++ b/app/page.js
@@ -15,6 +15,7 @@ import {
 } from "@/app/components";
 import { useListingGenerator } from "@/app/hooks/use-listing-generator";
 import { getApiBase, withUserId } from "@/app/lib/api";
+import { getSessionBasics } from "@/app/lib/session";
 import {
   VB_ENV_DEFAULT_KEY,
   VB_FLOW_MODE,
@@ -160,8 +161,7 @@ function serializeWalkthroughSeen(value) {
 
 export default function Home() {
   const { data: session } = authClient.useSession();
-  const isAdmin = Boolean(session?.user?.isAdmin);
-  const userId = session?.session?.userId || session?.user?.id || session?.user?.email || null;
+  const { userId, isAdmin } = getSessionBasics(session);
   const fileInputRef = useRef(null);
   const cameraInputRef = useRef(null);
   const [selectedFile, setSelectedFile] = useState(null);

--- a/app/studio/admin/page.js
+++ b/app/studio/admin/page.js
@@ -4,12 +4,13 @@ export const dynamic = "force-dynamic";
 import { useEffect, useState } from "react";
 import { createAuthClient } from "better-auth/react";
 import { getApiBase } from "@/app/lib/api";
+import { getSessionBasics } from "@/app/lib/session";
 
 const authClient = createAuthClient();
 
 export default function StudioAdminPage() {
   const { data: session } = authClient.useSession();
-  const isAdmin = Boolean(session?.user?.isAdmin);
+  const { isAdmin } = getSessionBasics(session);
   const [active, setActive] = useState("env"); // env | model | pose
 
   if (!isAdmin) {

--- a/app/studio/page.js
+++ b/app/studio/page.js
@@ -4,6 +4,7 @@ export const dynamic = "force-dynamic";
 import { useEffect, useMemo, useState } from "react";
 import { createAuthClient } from "better-auth/react";
 import { getApiBase, withUserId } from "@/app/lib/api";
+import { getSessionBasics } from "@/app/lib/session";
 import { VB_STUDIO_ACTIVE_TAB, VB_STUDIO_MODEL_GENDER } from "@/app/lib/storage-keys";
 import { CheckCircle2, MinusCircle, PlusCircle, Trash2 } from "lucide-react";
 
@@ -14,8 +15,7 @@ const GENDER_FILTERS = ["all", "man", "woman"];
 
 export default function StudioPage() {
   const { data: session } = authClient.useSession();
-  const userId = session?.session?.userId || session?.user?.id || session?.user?.email || null;
-  const isAdmin = Boolean(session?.user?.isAdmin);
+  const { userId, isAdmin } = getSessionBasics(session);
 
   const [activeSection, setActiveSection] = useState("environment");
   const [envLibraryView, setEnvLibraryView] = useState("generated");


### PR DESCRIPTION
## Summary
- add a shared `getSessionBasics` helper that normalizes the session user id/admin flags
- refactor session consumers to rely on the helper instead of reimplementing the fallback chain

## Linked Issues
- N/A

## Screenshots / Recordings
- N/A

## Env & Migration Notes
- None

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68cdb527b67083338cde7dca30e0539d