### PR TITLE
style: honor Geist font for body text

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -22,5 +22,5 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans), Arial, Helvetica, sans-serif;
 }


### PR DESCRIPTION
## Summary
- ensure the global body font stack starts with the Geist font variable from next/font
- allow the global stack to fall back to system sans-serif fonts when the variable is unavailable

## Testing
- npm run lint

## Linked Issues
- n/a

## Screenshots
- n/a (no visual change)

## Environment / Migration Notes
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68cdd796fb6c83339a9f124709c97e53