### PR TITLE
Improve top nav aria annotations

### DIFF
--- a/app/components/top-nav.js
+++ b/app/components/top-nav.js
@@ -25,6 +25,8 @@ export default function TopNav() {
             <Link
               key={link.href}
               href={link.href}
+              aria-current={active ? "page" : undefined}
+              aria-label={active ? `${link.label} current page` : link.label}
               className={clsx(
                 "flex h-12 min-w-[72px] flex-col items-center justify-center rounded-xl px-3 text-xs font-medium transition",
                 active


### PR DESCRIPTION
## Summary
- set aria-current="page" on active entries in the floating top nav
- add dynamic aria-labels that announce when the current page is active

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdd7eff35083339df05f51ec8d7b26