### PR TITLE
Refresh glassmorphism palette and surfaces

### DIFF
--- a/app/components/info-tooltip.js
+++ b/app/components/info-tooltip.js
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useFloating, offset, flip, shift, arrow, autoUpdate } from "@floating-ui/react";
 import { AnimatePresence, motion } from "framer-motion";
 import clsx from "clsx";
-import { palette, radius, transitions } from "@/app/lib/theme";
+import { palette, radius, shadows, transitions } from "@/app/lib/theme";
 
 export function InfoTooltip({ label, description, className, side = "top", children }) {
   const [open, setOpen] = useState(false);
@@ -52,20 +52,26 @@ export function InfoTooltip({ label, description, className, side = "top", child
               className="p-3"
               style={{
                 borderRadius: radius.md,
-                background: palette.background,
+                background: palette.card,
                 color: palette.textPrimary,
                 border: `1px solid ${palette.cardBorder}`,
-                boxShadow: "0 12px 40px rgba(15, 23, 42, 0.45)",
+                backdropFilter: "blur(var(--blur-surface))",
+                WebkitBackdropFilter: "blur(var(--blur-surface))",
+                boxShadow: shadows.soft,
               }}
             >
               <p className="text-sm font-semibold mb-1">{label}</p>
-              {description && <p className="text-xs leading-snug text-slate-300">{description}</p>}
+              {description && (
+                <p className="text-xs leading-snug" style={{ color: palette.textSecondary }}>
+                  {description}
+                </p>
+              )}
             </div>
             <div
               ref={setArrowEl}
               className="absolute h-2 w-2 rotate-45"
               style={{
-                background: palette.background,
+                background: palette.card,
                 borderLeft: `1px solid ${palette.cardBorder}`,
                 borderTop: `1px solid ${palette.cardBorder}`,
                 left: middlewareData.arrow?.x != null ? middlewareData.arrow.x : "",

--- a/app/components/option-picker.js
+++ b/app/components/option-picker.js
@@ -39,8 +39,16 @@ export function OptionPicker({
     <div className="flex flex-col gap-3">
       {(label || description) && (
         <div>
-          {label && <div className="text-sm font-semibold text-slate-100">{label}</div>}
-          {description && <p className="text-xs text-slate-400 mt-1">{description}</p>}
+          {label && (
+            <div className="text-sm font-semibold" style={{ color: palette.textPrimary }}>
+              {label}
+            </div>
+          )}
+          {description && (
+            <p className="text-xs mt-1" style={{ color: palette.textSecondary }}>
+              {description}
+            </p>
+          )}
         </div>
       )}
       <div className="grid gap-2 sm:grid-cols-2">
@@ -53,26 +61,27 @@ export function OptionPicker({
               onClick={() => toggle(option.value)}
               className={clsx(
                 "text-left px-4 py-3 rounded-lg border transition flex flex-col gap-1",
-                selected
-                  ? "border-transparent"
-                  : "border-white/10 hover:border-white/20"
+                selected && "shadow-[0_18px_45px_rgba(0,119,130,0.18)]"
               )}
               style={{
-                backgroundColor: selected ? `${palette.accentSoft}` : "rgba(15,23,42,0.5)",
+                backgroundColor: selected ? palette.accentSoft : palette.background,
                 color: palette.textPrimary,
                 borderRadius: radius.md,
+                borderColor: selected ? palette.accent : palette.cardBorder,
                 transition: transitions.base,
               }}
             >
               <span className="text-sm font-medium">{option.label}</span>
               {option.description && (
-                <span className="text-xs text-slate-400 leading-snug">{option.description}</span>
+                <span className="text-xs leading-snug" style={{ color: palette.textSecondary }}>
+                  {option.description}
+                </span>
               )}
               {option.badge && (
                 <span
                   className="text-[10px] uppercase tracking-wide mt-1 inline-flex self-start rounded-full px-2 py-0.5"
                   style={{
-                    backgroundColor: `${palette.accent}22`,
+                    backgroundColor: palette.accentSoft,
                     color: palette.accent,
                   }}
                 >

--- a/app/components/prompt-preview-card.js
+++ b/app/components/prompt-preview-card.js
@@ -11,10 +11,17 @@ export function PromptPreviewCard({ prompt, onChange, dirty, onReset }) {
 
   return (
     <section className="flex flex-col gap-3" style={styles}>
-      <header className="flex items-center justify-between px-4 py-3 border-b border-white/5">
+      <header
+        className="flex items-center justify-between px-4 py-3 border-b"
+        style={{ borderColor: palette.cardBorder }}
+      >
         <div>
-          <h3 className="text-sm font-semibold text-slate-100">Prompt preview</h3>
-          <p className="text-xs text-slate-400 mt-1">Live snapshot of what we send to Gemini. Override when you need something bespoke.</p>
+          <h3 className="text-sm font-semibold" style={{ color: palette.textPrimary }}>
+            Prompt preview
+          </h3>
+          <p className="text-xs mt-1" style={{ color: palette.textSecondary }}>
+            Live snapshot of what we send to Gemini. Override when you need something bespoke.
+          </p>
         </div>
         <div className="flex items-center gap-2">
           {dirty && (
@@ -52,9 +59,15 @@ export function PromptPreviewCard({ prompt, onChange, dirty, onReset }) {
               onChange={(e) => onChange?.(e.target.value)}
               className={clsx(
                 "w-full min-h-[160px] text-sm leading-relaxed resize-y focus:outline-none p-4",
-                "bg-transparent border border-white/10 focus:border-white/20 rounded-lg"
+                "border rounded-lg focus:ring-2 focus:ring-[rgba(0,119,130,0.28)]"
               )}
-              style={{ color: palette.textPrimary, borderRadius: radius.md }}
+              style={{
+                color: palette.textPrimary,
+                borderRadius: radius.md,
+                borderColor: palette.cardBorder,
+                backgroundColor: palette.background,
+                transition: transitions.base,
+              }}
             />
           </motion.div>
         )}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,26 +1,73 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #f2f8f9;
+  --foreground: #0f1d21;
+  --foreground-muted: rgba(15, 29, 33, 0.68);
+  --surface: rgba(255, 255, 255, 0.72);
+  --surface-strong: rgba(255, 255, 255, 0.9);
+  --border-subtle: rgba(0, 119, 130, 0.16);
+  --accent: #007782;
+  --accent-soft: rgba(0, 119, 130, 0.18);
+  --glass-blur: 18px;
+  --shadow-soft: 0 28px 68px rgba(2, 44, 52, 0.16);
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-foreground-muted: var(--foreground-muted);
+  --color-surface: var(--surface);
+  --color-surface-strong: var(--surface-strong);
+  --color-border-subtle: var(--border-subtle);
+  --color-accent: var(--accent);
+  --color-accent-soft: var(--accent-soft);
+  --blur-surface: var(--glass-blur);
+  --shadow-surface: var(--shadow-soft);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+    --background: #051417;
+    --foreground: #e6f5f7;
+    --foreground-muted: rgba(220, 238, 241, 0.72);
+    --surface: rgba(8, 34, 38, 0.78);
+    --surface-strong: rgba(6, 28, 33, 0.88);
+    --border-subtle: rgba(0, 119, 130, 0.35);
+    --accent: #007782;
+    --accent-soft: rgba(0, 160, 176, 0.32);
+    --glass-blur: 20px;
+    --shadow-soft: 0 32px 80px rgba(0, 24, 29, 0.38);
+  }
+
+  body::before {
+    background:
+      radial-gradient(120% 120% at 18% 12%, rgba(0, 160, 176, 0.36), transparent 55%),
+      radial-gradient(160% 160% at 82% 88%, rgba(0, 120, 130, 0.28), transparent 62%);
+    opacity: 0.6;
   }
 }
 
 body {
-  background: var(--background);
+  position: relative;
+  min-height: 100dvh;
+  background-color: var(--background);
   color: var(--foreground);
   font-family: var(--font-sans), Arial, Helvetica, sans-serif;
+  overflow-x: hidden;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background:
+    radial-gradient(120% 120% at 18% 10%, var(--accent-soft), transparent 60%),
+    radial-gradient(150% 150% at 85% 90%, rgba(0, 119, 130, 0.22), transparent 65%);
+  filter: blur(120px);
+  opacity: 0.5;
+  pointer-events: none;
+  z-index: -1;
 }

--- a/app/lib/theme.js
+++ b/app/lib/theme.js
@@ -5,20 +5,20 @@ export const radius = {
 };
 
 export const palette = {
-  background: "#0f172a",
-  card: "rgba(15, 23, 42, 0.8)",
-  cardBorder: "rgba(148, 163, 184, 0.2)",
-  accent: "#38bdf8",
-  accentSoft: "rgba(56, 189, 248, 0.2)",
+  background: "var(--color-surface)",
+  card: "var(--color-surface-strong)",
+  cardBorder: "var(--color-border-subtle)",
+  accent: "#007782",
+  accentSoft: "var(--color-accent-soft)",
   positive: "#22c55e",
   warning: "#f97316",
   danger: "#ef4444",
-  textPrimary: "#f8fafc",
-  textSecondary: "#cbd5f5",
+  textPrimary: "var(--color-foreground)",
+  textSecondary: "var(--color-foreground-muted)",
 };
 
 export const shadows = {
-  soft: "0 10px 50px rgba(15, 23, 42, 0.35)",
+  soft: "var(--shadow-surface)",
 };
 
 export const transitions = {
@@ -30,7 +30,8 @@ export function surfaceStyles() {
     borderRadius: radius.lg,
     border: `1px solid ${palette.cardBorder}`,
     background: palette.card,
-    backdropFilter: "blur(16px)",
+    backdropFilter: "blur(var(--blur-surface))",
+    WebkitBackdropFilter: "blur(var(--blur-surface))",
     boxShadow: shadows.soft,
   };
 }


### PR DESCRIPTION
## Summary
- add Calypso-driven glassmorphism CSS variables and expose them through the inline theme for light and dark modes
- align the theme palette, surface helper, and UI components with the new surface and accent tokens so cards and tooltips reuse the glass styles

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cddb84a9b48333ab9f4667af0708c1