### PR TITLE
ui: align shell and nav with new theme tokens

### DIFF
--- a/app/components/app-shell.js
+++ b/app/components/app-shell.js
@@ -5,12 +5,35 @@ import TopNav from "./top-nav";
 
 export default function AppShell({ children }) {
   return (
-    <div className="min-h-screen bg-background text-foreground">
-      <main className="mx-auto w-full max-w-5xl px-4 pb-28 pt-6">
-        {children}
+    <div className="relative min-h-screen overflow-hidden bg-[var(--color-background)] text-[var(--color-foreground)]">
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute left-1/2 top-[-20%] h-[520px] w-[520px] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,var(--color-accent)_0%,transparent_65%)] opacity-40 blur-3xl" />
+        <div className="absolute inset-x-0 bottom-[-45%] mx-auto h-[620px] w-[620px] max-w-[90vw] rounded-full bg-[radial-gradient(circle_at_center,var(--color-accent-soft)_0%,transparent_70%)] opacity-60 blur-[160px]" />
+      </div>
+      <main className="relative z-10 mx-auto w-full max-w-5xl px-4 pb-28 pt-10">
+        <div className="rounded-3xl border border-[var(--color-border)] bg-[var(--color-surface)] p-6 shadow-[0_40px_120px_var(--color-border-strong)] backdrop-blur sm:p-10">
+          {children}
+        </div>
       </main>
       <TopNav />
-      <Toaster position="top-center" toastOptions={{ duration: 4000 }} />
+      <Toaster
+        position="top-center"
+        toastOptions={{
+          duration: 4000,
+          style: {
+            background: "var(--color-surface-strong)",
+            color: "var(--color-foreground)",
+            border: "1px solid var(--color-border)",
+            boxShadow: "0 30px 70px var(--color-border-strong)",
+          },
+          success: {
+            iconTheme: {
+              primary: "var(--color-accent)",
+              secondary: "var(--color-surface)",
+            },
+          },
+        }}
+      />
     </div>
   );
 }

--- a/app/components/top-nav.js
+++ b/app/components/top-nav.js
@@ -17,7 +17,7 @@ export default function TopNav() {
 
   return (
     <nav className="pointer-events-none fixed bottom-4 left-0 right-0 z-40 flex justify-center">
-      <div className="pointer-events-auto flex items-center gap-1 rounded-2xl border border-black/10 bg-background/90 px-2 py-2 shadow-lg shadow-black/10 backdrop-blur dark:border-white/10 dark:shadow-black/40">
+      <div className="pointer-events-auto flex items-center gap-1 rounded-2xl border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] px-2 py-2 shadow-[0_18px_60px_var(--color-border-strong)] backdrop-blur">
         {links.map((link) => {
           const Icon = link.icon;
           const active = pathname === link.href || pathname?.startsWith(`${link.href}/`);
@@ -28,10 +28,10 @@ export default function TopNav() {
               aria-current={active ? "page" : undefined}
               aria-label={active ? `${link.label} current page` : link.label}
               className={clsx(
-                "flex h-12 min-w-[72px] flex-col items-center justify-center rounded-xl px-3 text-xs font-medium transition",
+                "flex h-12 min-w-[72px] flex-col items-center justify-center rounded-xl px-3 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-surface-strong)]",
                 active
-                  ? "bg-foreground text-background shadow-sm"
-                  : "text-foreground/70 hover:text-foreground"
+                  ? "bg-[var(--color-accent)] text-[var(--color-foreground)] shadow-[0_12px_35px_var(--color-border-strong)]"
+                  : "text-[var(--color-foreground)]/70 hover:bg-[var(--color-accent-soft)] hover:text-[var(--color-foreground)] focus-visible:bg-[var(--color-accent-soft)] focus-visible:text-[var(--color-foreground)]"
               )}
             >
               <Icon className="mb-1 size-4" />

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,21 +1,39 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #f8fafc;
+  --foreground: #0f172a;
+  --surface: rgba(255, 255, 255, 0.75);
+  --surface-strong: rgba(255, 255, 255, 0.92);
+  --border: rgba(15, 23, 42, 0.08);
+  --border-strong: rgba(15, 23, 42, 0.16);
+  --accent: #38bdf8;
+  --accent-soft: rgba(56, 189, 248, 0.18);
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-surface: var(--surface);
+  --color-surface-strong: var(--surface-strong);
+  --color-border: var(--border);
+  --color-border-strong: var(--border-strong);
+  --color-accent: var(--accent);
+  --color-accent-soft: var(--accent-soft);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+    --background: #04060d;
+    --foreground: #e2e8f0;
+    --surface: rgba(15, 23, 42, 0.62);
+    --surface-strong: rgba(15, 23, 42, 0.78);
+    --border: rgba(148, 163, 184, 0.18);
+    --border-strong: rgba(148, 163, 184, 0.32);
+    --accent: #38bdf8;
+    --accent-soft: rgba(56, 189, 248, 0.24);
   }
 }
 


### PR DESCRIPTION
## Summary
- expand the global theme tokens with surface, border, and accent variables for light and dark palettes
- restyle the app shell with blurred accent gradients, a surface panel wrapper, and accent-aligned toaster styling
- refresh the bottom nav rail to use the new surface tokens, accent active states, and accessible focus treatments

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cddb8630d88333bc52110f995235d4