### PR TITLE
ui: adopt surface tokens and accent styling

### DIFF
--- a/app/components/admin-review-panel.js
+++ b/app/components/admin-review-panel.js
@@ -17,14 +17,26 @@ export function AdminReviewPanel({
   poseStatusItems,
 }) {
   return (
-    <div className="space-y-4 rounded-2xl border border-black/10 bg-black/5 p-4 dark:border-white/15 dark:bg-white/5 sm:p-6">
+    <div className="space-y-4 rounded-2xl border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)] p-4 sm:p-6">
       <div className="flex flex-wrap items-center gap-2 text-xs">
-        <span className="rounded-full border border-foreground/15 px-3 py-1">{gender}</span>
-        <span className="rounded-full border border-foreground/15 px-3 py-1">Env: {environmentSummary}</span>
-        <span className="rounded-full border border-foreground/15 px-3 py-1">Poses: {poseSummary || "–"}</span>
-        <span className="rounded-full border border-foreground/15 px-3 py-1">Model: {modelSummary}</span>
-        <span className="rounded-full border border-foreground/15 px-3 py-1">Flow: {flowMode}</span>
-        <span className="rounded-full border border-foreground/15 px-3 py-1">Type: {garmentSummary}</span>
+        <span className="rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-surface)] px-3 py-1 text-[color:var(--color-text-secondary)]">
+          {gender}
+        </span>
+        <span className="rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-surface)] px-3 py-1 text-[color:var(--color-text-secondary)]">
+          Env: {environmentSummary}
+        </span>
+        <span className="rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-surface)] px-3 py-1 text-[color:var(--color-text-secondary)]">
+          Poses: {poseSummary || "–"}
+        </span>
+        <span className="rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-surface)] px-3 py-1 text-[color:var(--color-text-secondary)]">
+          Model: {modelSummary}
+        </span>
+        <span className="rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-surface)] px-3 py-1 text-[color:var(--color-text-secondary)]">
+          Flow: {flowMode}
+        </span>
+        <span className="rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-surface)] px-3 py-1 text-[color:var(--color-text-secondary)]">
+          Type: {garmentSummary}
+        </span>
       </div>
       <PromptPreviewCard
         prompt={prompt}

--- a/app/components/admin-tools-card.js
+++ b/app/components/admin-tools-card.js
@@ -3,16 +3,18 @@
 import { Loader2 } from "lucide-react";
 
 export function AdminToolsCard({ busy, onInitDb }) {
+  const buttonClasses = busy
+    ? "bg-[color:var(--color-accent)]/60 text-[color:var(--color-accent-contrast)]/80"
+    : "bg-[color:var(--color-accent)] text-[color:var(--color-accent-contrast)]";
+
   return (
-    <div className="rounded-2xl border border-black/10 bg-black/5 p-4 text-sm dark:border-white/15 dark:bg-white/5">
+    <div className="rounded-2xl border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)] p-4 text-sm">
       <h2 className="text-sm font-semibold">Admin tools</h2>
       <button
         type="button"
         onClick={onInitDb}
         disabled={busy}
-        className={`mt-3 inline-flex w-full items-center justify-center gap-2 rounded-lg border px-3 py-2 text-xs font-semibold ${
-          busy ? "opacity-60" : ""
-        }`}
+        className={`mt-3 inline-flex w-full items-center justify-center gap-2 rounded-lg px-3 py-2 text-xs font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-background)] ${buttonClasses}`}
       >
         {busy ? (
           <>

--- a/app/components/description-settings.js
+++ b/app/components/description-settings.js
@@ -1,5 +1,7 @@
 "use client";
 
+import clsx from "clsx";
+
 const CONDITIONS = ["Brand new", "Very good", "Good"];
 const SIZES = ["xs", "s", "m", "l", "xl"];
 
@@ -12,21 +14,25 @@ export function DescriptionSettings({
   onConditionChange,
 }) {
   return (
-    <div className="mt-4 space-y-3 rounded-xl border border-foreground/15 bg-background/40 p-4">
-      <div className="flex items-center justify-between text-xs text-foreground/70">
+    <div className="mt-4 space-y-3 rounded-xl border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)] p-4">
+      <div className="flex items-center justify-between text-xs text-[color:var(--color-text-secondary)]">
         <span>Generate product description</span>
         <button
           type="button"
           onClick={() => onToggle(!enabled)}
-          className={`relative inline-flex h-6 w-12 items-center rounded-full transition ${
-            enabled ? "bg-foreground" : "bg-foreground/30"
-          }`}
+          className={clsx(
+            "relative inline-flex h-6 w-12 items-center rounded-full border transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-background)]",
+            enabled
+              ? "border-transparent bg-[color:var(--color-accent)]"
+              : "border-[color:var(--color-border)] bg-[color:var(--color-surface)]"
+          )}
           aria-pressed={enabled}
         >
           <span
-            className={`inline-block h-5 w-5 transform rounded-full bg-background transition ${
+            className={clsx(
+              "inline-block h-5 w-5 transform rounded-full bg-[color:var(--color-background)] shadow transition",
               enabled ? "translate-x-6" : "translate-x-1"
-            }`}
+            )}
           />
         </button>
       </div>
@@ -34,14 +40,14 @@ export function DescriptionSettings({
         <div className="grid grid-cols-2 gap-2 text-sm">
           <input
             type="text"
-            className="col-span-2 h-9 rounded-lg border border-foreground/15 bg-background/40 px-3"
+            className="col-span-2 h-9 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] px-3 focus:outline-none focus:ring-2 focus:ring-[color:var(--color-accent)] focus:ring-offset-2 focus:ring-offset-[color:var(--color-background)]"
             placeholder="Brand (e.g., Nike, Zara)"
             value={desc.brand}
             onChange={(e) => onDescFieldChange("brand", e.target.value)}
           />
           <input
             type="text"
-            className="col-span-2 h-9 rounded-lg border border-foreground/15 bg-background/40 px-3"
+            className="col-span-2 h-9 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] px-3 focus:outline-none focus:ring-2 focus:ring-[color:var(--color-accent)] focus:ring-offset-2 focus:ring-offset-[color:var(--color-background)]"
             placeholder="Model (e.g., Air Max 90)"
             value={desc.productModel}
             onChange={(e) => onDescFieldChange("productModel", e.target.value)}
@@ -53,9 +59,12 @@ export function DescriptionSettings({
                   key={condition}
                   type="button"
                   onClick={() => onConditionChange(condition)}
-                  className={`h-8 rounded-full border px-3 text-xs ${
-                    productCondition === condition ? "border-foreground" : "border-foreground/20"
-                  }`}
+                  className={clsx(
+                    "h-8 rounded-full border px-3 text-xs transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-background)]",
+                    productCondition === condition
+                      ? "border-transparent bg-[color:var(--color-accent)] text-[color:var(--color-accent-contrast)]"
+                      : "border-[color:var(--color-border)] bg-[color:var(--color-surface)] text-[color:var(--color-text-secondary)] hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-surface-strong)]"
+                  )}
                   aria-pressed={productCondition === condition}
                 >
                   {condition}
@@ -70,9 +79,12 @@ export function DescriptionSettings({
                   key={size}
                   type="button"
                   onClick={() => onDescFieldChange("size", size)}
-                  className={`h-8 rounded-full border px-3 text-xs uppercase ${
-                    desc.size === size ? "border-foreground" : "border-foreground/20"
-                  }`}
+                  className={clsx(
+                    "h-8 rounded-full border px-3 text-xs uppercase transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-background)]",
+                    desc.size === size
+                      ? "border-transparent bg-[color:var(--color-accent)] text-[color:var(--color-accent-contrast)]"
+                      : "border-[color:var(--color-border)] bg-[color:var(--color-surface)] text-[color:var(--color-text-secondary)] hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-surface-strong)]"
+                  )}
                   aria-pressed={desc.size === size}
                 >
                   {size}

--- a/app/components/garment-type-selector.js
+++ b/app/components/garment-type-selector.js
@@ -1,5 +1,7 @@
 "use client";
 
+import clsx from "clsx";
+
 import { InfoTooltip } from "./info-tooltip";
 
 const TYPES = ["top", "bottom", "full"];
@@ -7,28 +9,31 @@ const TYPES = ["top", "bottom", "full"];
 export function GarmentTypeSelector({ value, onChange }) {
   return (
     <div className="mt-4">
-      <label className="inline-flex items-center gap-2 text-xs font-medium text-foreground/80">
+      <label className="inline-flex items-center gap-2 text-xs font-medium text-[color:var(--color-text-secondary)]">
         Garment type
         <InfoTooltip
           label="Garment type"
           description="Set to Top/Bottom/Full if you know it. Leave empty to auto-detect once and cache on the listing."
         />
       </label>
-      <div className="mt-2 grid grid-cols-3 overflow-hidden rounded-lg border border-foreground/15">
+      <div className="mt-2 grid grid-cols-3 overflow-hidden rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]">
         {TYPES.map((t) => (
           <button
             key={t}
             type="button"
             onClick={() => onChange(value === t ? null : t)}
-            className={`h-10 text-xs font-medium uppercase tracking-wide transition ${
-              value === t ? "bg-foreground text-background" : "text-foreground/70"
-            }`}
+            className={clsx(
+              "h-10 text-xs font-medium uppercase tracking-wide transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-background)]",
+              value === t
+                ? "bg-[color:var(--color-accent)] text-[color:var(--color-accent-contrast)]"
+                : "text-[color:var(--color-text-secondary)] hover:bg-[color:var(--color-surface-strong)]"
+            )}
           >
             {t}
           </button>
         ))}
       </div>
-      {!value && <p className="mt-1 text-[11px] text-foreground/50">Auto-detect if not set.</p>}
+      {!value && <p className="mt-1 text-[11px] text-[color:var(--color-text-tertiary)]">Auto-detect if not set.</p>}
     </div>
   );
 }

--- a/app/components/info-tooltip.js
+++ b/app/components/info-tooltip.js
@@ -59,7 +59,9 @@ export function InfoTooltip({ label, description, className, side = "top", child
               }}
             >
               <p className="text-sm font-semibold mb-1">{label}</p>
-              {description && <p className="text-xs leading-snug text-slate-300">{description}</p>}
+              {description && (
+                <p className="text-xs leading-snug text-[color:var(--color-text-secondary)]">{description}</p>
+              )}
             </div>
             <div
               ref={setArrowEl}

--- a/app/components/option-picker.js
+++ b/app/components/option-picker.js
@@ -52,13 +52,14 @@ export function OptionPicker({
               type="button"
               onClick={() => toggle(option.value)}
               className={clsx(
-                "text-left px-4 py-3 rounded-lg border transition flex flex-col gap-1",
+                "text-left px-4 py-3 rounded-lg border transition flex flex-col gap-1 ring-1",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)]",
+                "focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-background)]",
                 selected
-                  ? "border-transparent"
-                  : "border-white/10 hover:border-white/20"
+                  ? "border-transparent bg-[color:var(--color-accent-soft)] ring-[color:var(--color-accent)]"
+                  : "border-[color:var(--color-border)] bg-[color:var(--color-surface)] ring-[color:var(--color-border-muted)] hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-surface-strong)]"
               )}
               style={{
-                backgroundColor: selected ? `${palette.accentSoft}` : "rgba(15,23,42,0.5)",
                 color: palette.textPrimary,
                 borderRadius: radius.md,
                 transition: transitions.base,
@@ -66,13 +67,15 @@ export function OptionPicker({
             >
               <span className="text-sm font-medium">{option.label}</span>
               {option.description && (
-                <span className="text-xs text-slate-400 leading-snug">{option.description}</span>
+                <span className="text-xs leading-snug text-[color:var(--color-text-secondary)]">
+                  {option.description}
+                </span>
               )}
               {option.badge && (
                 <span
                   className="text-[10px] uppercase tracking-wide mt-1 inline-flex self-start rounded-full px-2 py-0.5"
                   style={{
-                    backgroundColor: `${palette.accent}22`,
+                    backgroundColor: palette.accentSoft,
                     color: palette.accent,
                   }}
                 >

--- a/app/components/pose-status-list.js
+++ b/app/components/pose-status-list.js
@@ -11,19 +11,19 @@ export function PoseStatusList({ items }) {
   };
 
   return (
-    <div className="rounded-xl border border-foreground/10 bg-background/40 p-4">
+    <div className="rounded-xl border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)] p-4">
       <h3 className="text-sm font-semibold">Generation status</h3>
-      <ul className="mt-2 space-y-2 text-xs">
+      <ul className="mt-2 space-y-2 text-xs text-[color:var(--color-text-secondary)]">
         {items.map(({ key, label, status, error }) => (
           <li key={key} className="flex items-start justify-between gap-3">
             <span className="font-medium">{label}</span>
             <span
               className={
                 status === "error"
-                  ? "text-red-500"
+                  ? "text-[color:var(--color-danger)]"
                   : status === "done"
-                    ? "text-green-400"
-                    : "text-foreground/60"
+                    ? "text-[color:var(--color-positive)]"
+                    : "text-[color:var(--color-text-secondary)]"
               }
             >
               {resolveStatusLabel(status, error)}

--- a/app/components/prompt-preview-card.js
+++ b/app/components/prompt-preview-card.js
@@ -11,10 +11,10 @@ export function PromptPreviewCard({ prompt, onChange, dirty, onReset }) {
 
   return (
     <section className="flex flex-col gap-3" style={styles}>
-      <header className="flex items-center justify-between px-4 py-3 border-b border-white/5">
+      <header className="flex items-center justify-between px-4 py-3 border-b border-[color:var(--color-border)]">
         <div>
-          <h3 className="text-sm font-semibold text-slate-100">Prompt preview</h3>
-          <p className="text-xs text-slate-400 mt-1">Live snapshot of what we send to Gemini. Override when you need something bespoke.</p>
+          <h3 className="text-sm font-semibold text-[color:var(--color-foreground)]">Prompt preview</h3>
+          <p className="text-xs text-[color:var(--color-text-secondary)] mt-1">Live snapshot of what we send to Gemini. Override when you need something bespoke.</p>
         </div>
         <div className="flex items-center gap-2">
           {dirty && (
@@ -52,7 +52,7 @@ export function PromptPreviewCard({ prompt, onChange, dirty, onReset }) {
               onChange={(e) => onChange?.(e.target.value)}
               className={clsx(
                 "w-full min-h-[160px] text-sm leading-relaxed resize-y focus:outline-none p-4",
-                "bg-transparent border border-white/10 focus:border-white/20 rounded-lg"
+                "bg-transparent border border-[color:var(--color-border)] focus:border-[color:var(--color-border-strong)] rounded-lg"
               )}
               style={{ color: palette.textPrimary, borderRadius: radius.md }}
             />

--- a/app/components/scene-model-options.js
+++ b/app/components/scene-model-options.js
@@ -1,5 +1,6 @@
 "use client";
 
+import clsx from "clsx";
 import Link from "next/link";
 import Image from "next/image";
 import { ImageOff } from "lucide-react";
@@ -37,25 +38,27 @@ export function SceneModelOptions({
   const showDescriptionWarning = !useModelImage && !selectedModelDefault?.description;
 
   return (
-    <div className="rounded-2xl border border-black/10 bg-black/5 dark:border-white/15 dark:bg-white/5">
+    <div className="rounded-2xl border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)]">
       <button
         type="button"
         onClick={onToggleCollapsed}
-        className="flex w-full items-center justify-between gap-3 px-4 py-3 text-left text-sm font-semibold"
+        className="flex w-full items-center justify-between gap-3 px-4 py-3 text-left text-sm font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-background)]"
       >
         <span>Scene & model options</span>
-        <span className="text-xs text-foreground/60">{collapsed ? "Show" : "Hide"}</span>
+        <span className="text-xs text-[color:var(--color-text-secondary)]">{collapsed ? "Show" : "Hide"}</span>
       </button>
       {!collapsed && (
-        <div className="border-t border-foreground/10 px-4 py-5">
+        <div className="border-t border-[color:var(--color-border-muted)] px-4 py-5">
           <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
             <div className="sm:col-span-2">
               <div className="flex items-center justify-between gap-3">
                 <div>
                   <p className="text-sm font-semibold">Model defaults</p>
-                  <p className="mt-1 text-xs text-foreground/60">Pick a Studio default image to set the person and gender.</p>
+                  <p className="mt-1 text-xs text-[color:var(--color-text-secondary)]">
+                    Pick a Studio default image to set the person and gender.
+                  </p>
                 </div>
-                <Link href="/studio" className="text-xs text-foreground/60 underline">
+                <Link href="/studio" className="text-xs text-[color:var(--color-text-secondary)] underline">
                   Manage
                 </Link>
               </div>
@@ -69,11 +72,13 @@ export function SceneModelOptions({
                         key={model.gender}
                         type="button"
                         onClick={() => onSelectGender(model.gender)}
-                        className={`group w-32 flex-shrink-0 overflow-hidden rounded-xl border text-left transition ${
+                        className={clsx(
+                          "group w-32 flex-shrink-0 overflow-hidden rounded-xl border text-left transition",
+                          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-background)]",
                           selected
-                            ? "border-foreground ring-2 ring-foreground/40 bg-foreground/5 shadow-lg"
-                            : "border-foreground/15 hover:border-foreground/50"
-                        }`}
+                            ? "border-[color:var(--color-accent)] bg-[color:var(--color-accent-soft)] shadow-[0_18px_36px_rgba(12,23,37,0.16)]"
+                            : "border-[color:var(--color-border)] bg-[color:var(--color-surface)] hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-surface-strong)]"
+                        )}
                         aria-pressed={selected}
                       >
                         <div className="relative aspect-[3/4] w-full overflow-hidden">
@@ -87,21 +92,21 @@ export function SceneModelOptions({
                               unoptimized
                             />
                           ) : (
-                            <div className="flex h-full w-full items-center justify-center bg-foreground/10 text-foreground/50">
+                            <div className="flex h-full w-full items-center justify-center bg-[color:var(--color-surface)] text-[color:var(--color-text-tertiary)]">
                               <ImageOff className="size-6" aria-hidden="true" />
                             </div>
                           )}
                         </div>
                         <div className="px-3 py-2">
                           <p className="text-sm font-semibold capitalize">{model.name || genderLabel}</p>
-                          <p className="text-[11px] text-foreground/60">{genderLabel} fit</p>
+                          <p className="text-[11px] text-[color:var(--color-text-secondary)]">{genderLabel} fit</p>
                         </div>
                       </button>
                     );
                   })}
                 </div>
               ) : (
-                <div className="mt-3 rounded-lg border border-foreground/15 bg-background/40 p-3 text-xs text-foreground/60">
+                <div className="mt-3 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-3 text-xs text-[color:var(--color-text-secondary)]">
                   No Studio defaults yet. <Link href="/studio" className="underline">Add one</Link> to unlock a quicker flow.
                 </div>
               )}
@@ -126,35 +131,42 @@ export function SceneModelOptions({
               </div>
             )}
             <div className="sm:col-span-2">
-              <div className="flex items-center justify-between gap-3">
-                <div>
-                  <p className="text-sm font-semibold">Environment defaults</p>
-                  <p className="mt-1 text-xs text-foreground/60">Pick from your saved backgrounds. Add more in Studio to build a library.</p>
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold">Environment defaults</p>
+                    <p className="mt-1 text-xs text-[color:var(--color-text-secondary)]">
+                      Pick from your saved backgrounds. Add more in Studio to build a library.
+                    </p>
+                  </div>
+                  <Link href="/studio" className="text-xs text-[color:var(--color-text-secondary)] underline">
+                    Manage
+                  </Link>
                 </div>
-                <Link href="/studio" className="text-xs text-foreground/60 underline">
-                  Manage
-                </Link>
-              </div>
-              {envDefaultsLoading ? (
-                <div className="mt-3 flex gap-3 overflow-x-auto pb-1">
-                  {Array.from({ length: 4 }).map((_, i) => (
-                    <div key={i} className="h-32 w-32 flex-shrink-0 animate-pulse rounded-xl bg-foreground/10" />
-                  ))}
-                </div>
-              ) : envDefaults.length > 0 ? (
-                <div className="mt-3 flex gap-3 overflow-x-auto pb-1">
-                  {envDefaults.map((env) => {
+                {envDefaultsLoading ? (
+                  <div className="mt-3 flex gap-3 overflow-x-auto pb-1">
+                    {Array.from({ length: 4 }).map((_, i) => (
+                      <div
+                        key={i}
+                        className="h-32 w-32 flex-shrink-0 animate-pulse rounded-xl bg-[color:var(--color-surface)]"
+                      />
+                    ))}
+                  </div>
+                ) : envDefaults.length > 0 ? (
+                  <div className="mt-3 flex gap-3 overflow-x-auto pb-1">
+                    {envDefaults.map((env) => {
                     const selected = selectedEnvDefaultKey === env.s3_key;
                     return (
                       <button
                         key={env.s3_key}
                         type="button"
                         onClick={() => onSelectEnvironmentDefault(env.s3_key)}
-                        className={`group w-32 flex-shrink-0 overflow-hidden rounded-xl border text-left transition ${
+                        className={clsx(
+                          "group w-32 flex-shrink-0 overflow-hidden rounded-xl border text-left transition",
+                          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-background)]",
                           selected
-                            ? "border-foreground ring-2 ring-foreground/40 bg-foreground/5 shadow-lg"
-                            : "border-foreground/15 hover:border-foreground/50"
-                        }`}
+                            ? "border-[color:var(--color-accent)] bg-[color:var(--color-accent-soft)] shadow-[0_18px_36px_rgba(12,23,37,0.16)]"
+                            : "border-[color:var(--color-border)] bg-[color:var(--color-surface)] hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-surface-strong)]"
+                        )}
                         aria-pressed={selected}
                       >
                         <div className="relative aspect-[3/4] w-full overflow-hidden">
@@ -168,14 +180,16 @@ export function SceneModelOptions({
                               unoptimized
                             />
                           ) : (
-                            <div className="flex h-full w-full items-center justify-center bg-foreground/10 text-foreground/50">
+                            <div className="flex h-full w-full items-center justify-center bg-[color:var(--color-surface)] text-[color:var(--color-text-tertiary)]">
                               <ImageOff className="size-6" aria-hidden="true" />
                             </div>
                           )}
                         </div>
                         <div className="px-3 py-2">
                           <p className="text-sm font-semibold">{env.name || "Untitled"}</p>
-                          <p className="text-[11px] text-foreground/60">{selected ? "Current selection" : "Tap to select"}</p>
+                          <p className="text-[11px] text-[color:var(--color-text-secondary)]">
+                            {selected ? "Current selection" : "Tap to select"}
+                          </p>
                         </div>
                       </button>
                     );
@@ -184,20 +198,26 @@ export function SceneModelOptions({
               ) : (
                 <div className="mt-3 space-y-3">
                   <OptionPicker options={environmentOptions} value={environmentValue} onChange={onEnvironmentChange} />
-                  <p className="text-[11px] text-foreground/50">Save environment photos in Studio to see them here.</p>
+                  <p className="text-[11px] text-[color:var(--color-text-tertiary)]">
+                    Save environment photos in Studio to see them here.
+                  </p>
                 </div>
               )}
             </div>
             <div className="sm:col-span-2">
-              <div className="rounded-2xl border border-foreground/15 bg-background/60 p-4 shadow-sm">
+              <div className="rounded-2xl border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)] p-4 shadow-sm">
                 <div className="flex flex-wrap items-center justify-between gap-3">
                   <div>
                     <p className="text-sm font-semibold">Image count</p>
-                    <p className="mt-1 text-xs text-foreground/60">Pick how many images to generate (max {poseMax}).</p>
+                    <p className="mt-1 text-xs text-[color:var(--color-text-secondary)]">
+                      Pick how many images to generate (max {poseMax}).
+                    </p>
                   </div>
-                  <div className="inline-flex items-baseline gap-2 rounded-xl bg-foreground px-4 py-2 text-background shadow">
+                  <div className="inline-flex items-baseline gap-2 rounded-xl bg-[color:var(--color-accent)] px-4 py-2 text-[color:var(--color-accent-contrast)] shadow">
                     <span className="text-2xl font-semibold leading-none">{plannedImagesCount}</span>
-                    <span className="text-[11px] uppercase tracking-wide text-background/70">images</span>
+                    <span className="text-[11px] uppercase tracking-wide text-[color:var(--color-accent-contrast)]/70">
+                      images
+                    </span>
                   </div>
                 </div>
                 <div className="mt-4 grid grid-cols-5 gap-2">
@@ -208,11 +228,13 @@ export function SceneModelOptions({
                         key={count}
                         type="button"
                         onClick={() => onPoseCountChange(count)}
-                        className={`group flex h-10 items-center justify-center rounded-lg border text-sm font-semibold transition ${
+                        className={clsx(
+                          "group flex h-10 items-center justify-center rounded-lg border text-sm font-semibold transition",
+                          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-background)]",
                           checked
-                            ? "border-foreground bg-foreground text-background shadow"
-                            : "border-foreground/20 bg-background/80 text-foreground/70 hover:border-foreground/60 hover:text-foreground"
-                        }`}
+                            ? "border-[color:var(--color-accent)] bg-[color:var(--color-accent)] text-[color:var(--color-accent-contrast)] shadow"
+                            : "border-[color:var(--color-border)] bg-[color:var(--color-surface)] text-[color:var(--color-text-secondary)] hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-surface-strong)] hover:text-[color:var(--color-foreground)]"
+                        )}
                         aria-pressed={checked}
                       >
                         {count}
@@ -220,14 +242,16 @@ export function SceneModelOptions({
                     );
                   })}
                 </div>
-                <p className="mt-3 text-[11px] text-foreground/60">We’ll pick varied poses automatically for each image.</p>
+                <p className="mt-3 text-[11px] text-[color:var(--color-text-secondary)]">
+                  We’ll pick varied poses automatically for each image.
+                </p>
               </div>
             </div>
             <div className="sm:col-span-2">
-              <label className="text-xs text-foreground/70">Extra instructions</label>
+              <label className="text-xs text-[color:var(--color-text-secondary)]">Extra instructions</label>
               <textarea
                 rows={3}
-                className="mt-2 w-full rounded-lg border border-foreground/15 bg-background/40 px-3 py-2 text-sm"
+                className="mt-2 w-full rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[color:var(--color-accent)] focus:ring-offset-2 focus:ring-offset-[color:var(--color-background)]"
                 placeholder="Optional: add a style tweak, colours, or vibe"
                 value={extraInstructions}
                 onChange={(e) => onExtraChange(e.target.value)}

--- a/app/components/top-nav.js
+++ b/app/components/top-nav.js
@@ -17,7 +17,7 @@ export default function TopNav() {
 
   return (
     <nav className="pointer-events-none fixed bottom-4 left-0 right-0 z-40 flex justify-center">
-      <div className="pointer-events-auto flex items-center gap-1 rounded-2xl border border-black/10 bg-background/90 px-2 py-2 shadow-lg shadow-black/10 backdrop-blur dark:border-white/10 dark:shadow-black/40">
+      <div className="pointer-events-auto flex items-center gap-1 rounded-2xl border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)]/90 px-2 py-2 shadow-lg shadow-[rgba(12,23,37,0.15)] backdrop-blur">
         {links.map((link) => {
           const Icon = link.icon;
           const active = pathname === link.href || pathname?.startsWith(`${link.href}/`);
@@ -28,10 +28,10 @@ export default function TopNav() {
               aria-current={active ? "page" : undefined}
               aria-label={active ? `${link.label} current page` : link.label}
               className={clsx(
-                "flex h-12 min-w-[72px] flex-col items-center justify-center rounded-xl px-3 text-xs font-medium transition",
+                "flex h-12 min-w-[72px] flex-col items-center justify-center rounded-xl px-3 text-xs font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-background)]",
                 active
-                  ? "bg-foreground text-background shadow-sm"
-                  : "text-foreground/70 hover:text-foreground"
+                  ? "bg-[color:var(--color-accent)] text-[color:var(--color-accent-contrast)] shadow-sm"
+                  : "text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-foreground)]"
               )}
             >
               <Icon className="mb-1 size-4" />

--- a/app/components/upload-panel.js
+++ b/app/components/upload-panel.js
@@ -1,5 +1,6 @@
 "use client";
 
+import clsx from "clsx";
 import { Camera } from "lucide-react";
 
 export function UploadPanel({
@@ -24,17 +25,19 @@ export function UploadPanel({
   const titleDescriptionId = titleHelpText ? "listing-title-helper" : undefined;
 
   return (
-    <div className="rounded-2xl border border-black/10 bg-black/5 p-4 dark:border-white/15 dark:bg-white/5 sm:p-6">
+    <div className="rounded-2xl border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)] p-4 sm:p-6">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <h2 className="text-lg font-semibold">Upload garment</h2>
-          <p className="text-xs text-foreground/60">Drop a clear photo of the item you want the model to wear.</p>
+          <p className="text-xs text-[color:var(--color-text-secondary)]">
+            Drop a clear photo of the item you want the model to wear.
+          </p>
         </div>
         <div className="flex items-center gap-2 text-sm">
           <button
             type="button"
             onClick={onTriggerCamera}
-            className="inline-flex items-center gap-2 rounded-full border border-foreground/20 px-3 py-1.5 font-semibold text-foreground transition hover:border-foreground/40"
+            className="inline-flex items-center gap-2 rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-surface)] px-3 py-1.5 font-semibold text-[color:var(--color-foreground)] transition hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-surface-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-background)]"
           >
             <Camera className="size-4" aria-hidden="true" />
             <span>Take photo</span>
@@ -51,63 +54,81 @@ export function UploadPanel({
             onDrop={onDrop}
             onDragOver={onDragOver}
             onDragLeave={onDragLeave}
-            className={`flex aspect-[4/5] w-full items-center justify-center rounded-xl border border-dashed px-4 text-center transition-colors ${
-              isDragging ? "border-blue-500 bg-blue-500/10" : "border-foreground/20 hover:border-foreground/40"
-            }`}
+            className={clsx(
+              "flex aspect-[4/5] w-full items-center justify-center rounded-xl border border-dashed px-4 text-center transition-colors",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-background)]",
+              isDragging
+                ? "border-[color:var(--color-accent)] bg-[color:var(--color-accent-soft)]"
+                : "border-[color:var(--color-border)] bg-[color:var(--color-surface-soft)] hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-surface)]"
+            )}
           >
-            <div className="flex flex-col items-center gap-2 text-foreground/70">
+            <div className="flex flex-col items-center gap-2 text-[color:var(--color-text-secondary)]">
               <div className="size-14 rounded-full border border-dashed border-current/30 flex items-center justify-center">
                 <Camera className="size-6" />
               </div>
               <div className="text-sm">
-                <span className="font-medium text-foreground">Tap to upload</span> or drop an image
+                <span className="font-medium text-[color:var(--color-foreground)]">Tap to upload</span> or drop an image
               </div>
               <div className="text-xs">PNG, JPG, HEIC up to ~10MB</div>
               {isPreprocessing && <div className="mt-1 text-xs">Optimizing photo…</div>}
             </div>
           </button>
         ) : (
-          <div className="w-full overflow-hidden rounded-xl border border-foreground/15 bg-background/40">
+          <div className="w-full overflow-hidden rounded-xl border border-[color:var(--color-border)] bg-[color:var(--color-surface)]">
             <div className="relative w-full aspect-[4/5]">
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img src={previewUrl} alt="Selected garment" className="h-full w-full object-cover" />
               {isPreprocessing && (
-                <div className="absolute bottom-2 right-2 rounded-md border border-black/10 bg-background/80 px-2 py-1 text-[11px] dark:border-white/15">
+                <div className="absolute bottom-2 right-2 rounded-md border border-[color:var(--color-border-muted)] bg-[color:var(--color-surface-strong)] px-2 py-1 text-[11px]">
                   Optimizing…
                 </div>
               )}
-              <div className="absolute top-2 right-2 rounded-md border border-black/10 bg-background/80 px-2 py-1 text-[11px] dark:border-white/15">
+              <div className="absolute top-2 right-2 rounded-md border border-[color:var(--color-border-muted)] bg-[color:var(--color-surface-strong)] px-2 py-1 text-[11px]">
                 {plannedImagesCount} image{plannedImagesCount > 1 ? "s" : ""}
               </div>
             </div>
-            <div className="flex flex-wrap items-center justify-between gap-3 border-t border-foreground/10 p-3 text-sm">
+            <div className="flex flex-wrap items-center justify-between gap-3 border-t border-[color:var(--color-border-muted)] p-3 text-sm">
               <div className="min-w-0">
                 <p className="truncate font-medium">{selectedFile?.name || "Selected image"}</p>
-                <p className="text-xs text-foreground/60">{selectedFile?.size ? `${Math.round(selectedFile.size / 1024)} KB` : ""}</p>
+                <p className="text-xs text-[color:var(--color-text-secondary)]">
+                  {selectedFile?.size ? `${Math.round(selectedFile.size / 1024)} KB` : ""}
+                </p>
               </div>
               <div className="flex items-center gap-2">
-                <button type="button" onClick={onTriggerPick} className="h-9 rounded-lg bg-foreground px-3 text-sm font-medium text-background">Change</button>
-                <button type="button" onClick={onClearSelection} className="h-9 rounded-lg border border-foreground/20 px-3 text-sm font-medium">Remove</button>
+                <button
+                  type="button"
+                  onClick={onTriggerPick}
+                  className="h-9 rounded-lg bg-[color:var(--color-accent)] px-3 text-sm font-medium text-[color:var(--color-accent-contrast)] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-background)]"
+                >
+                  Change
+                </button>
+                <button
+                  type="button"
+                  onClick={onClearSelection}
+                  className="h-9 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] px-3 text-sm font-medium transition hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-surface-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-background)]"
+                >
+                  Remove
+                </button>
               </div>
             </div>
           </div>
         )}
       </div>
       <div className="mt-4">
-        <label className="text-xs text-foreground/70" htmlFor="listing-title">
+        <label className="text-xs text-[color:var(--color-text-secondary)]" htmlFor="listing-title">
           Listing title
         </label>
         <input
           id="listing-title"
           type="text"
           placeholder="Give this generation a name"
-          className="mt-2 h-10 w-full rounded-lg border border-foreground/15 bg-background/40 px-3 text-sm"
+          className="mt-2 h-10 w-full rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] px-3 text-sm focus:outline-none focus:ring-2 focus:ring-[color:var(--color-accent)] focus:ring-offset-2 focus:ring-offset-[color:var(--color-background)]"
           value={title}
           onChange={(e) => onTitleChange(e.target.value)}
           aria-describedby={titleDescriptionId}
         />
         {titleHelpText ? (
-          <p id={titleDescriptionId} className="mt-2 text-xs text-foreground/60">
+          <p id={titleDescriptionId} className="mt-2 text-xs text-[color:var(--color-text-secondary)]">
             {titleHelpText}
           </p>
         ) : null}

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,11 +3,43 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --surface-soft: rgba(12, 23, 37, 0.03);
+  --surface: rgba(12, 23, 37, 0.06);
+  --surface-strong: rgba(12, 23, 37, 0.1);
+  --border-muted: rgba(12, 23, 37, 0.08);
+  --border: rgba(12, 23, 37, 0.12);
+  --border-strong: rgba(12, 23, 37, 0.18);
+  --accent: #1ca4b8;
+  --accent-soft: rgba(28, 164, 184, 0.18);
+  --accent-contrast: #ffffff;
+  --text-secondary: rgba(23, 23, 23, 0.68);
+  --text-tertiary: rgba(23, 23, 23, 0.52);
+  --overlay: rgba(10, 19, 34, 0.76);
+  --shadow-soft: 0 24px 64px rgba(12, 23, 37, 0.12);
+  --color-positive: #22c55e;
+  --color-warning: #f97316;
+  --color-danger: #ef4444;
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-surface-soft: var(--surface-soft);
+  --color-surface: var(--surface);
+  --color-surface-strong: var(--surface-strong);
+  --color-border-muted: var(--border-muted);
+  --color-border: var(--border);
+  --color-border-strong: var(--border-strong);
+  --color-accent: var(--accent);
+  --color-accent-soft: var(--accent-soft);
+  --color-accent-contrast: var(--accent-contrast);
+  --color-text-secondary: var(--text-secondary);
+  --color-text-tertiary: var(--text-tertiary);
+  --color-overlay: var(--overlay);
+  --shadow-soft: var(--shadow-soft);
+  --color-positive: var(--color-positive);
+  --color-warning: var(--color-warning);
+  --color-danger: var(--color-danger);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
@@ -15,7 +47,18 @@
 @media (prefers-color-scheme: dark) {
   :root {
     --background: #0a0a0a;
-    --foreground: #ededed;
+    --foreground: #f2f5f9;
+    --surface-soft: rgba(226, 232, 240, 0.05);
+    --surface: rgba(226, 232, 240, 0.08);
+    --surface-strong: rgba(226, 232, 240, 0.14);
+    --border-muted: rgba(226, 232, 240, 0.12);
+    --border: rgba(226, 232, 240, 0.2);
+    --border-strong: rgba(226, 232, 240, 0.28);
+    --accent-soft: rgba(28, 164, 184, 0.28);
+    --text-secondary: rgba(242, 245, 249, 0.72);
+    --text-tertiary: rgba(242, 245, 249, 0.56);
+    --overlay: rgba(2, 6, 12, 0.82);
+    --shadow-soft: 0 24px 64px rgba(2, 6, 12, 0.6);
   }
 }
 

--- a/app/lib/theme.js
+++ b/app/lib/theme.js
@@ -5,20 +5,21 @@ export const radius = {
 };
 
 export const palette = {
-  background: "#0f172a",
-  card: "rgba(15, 23, 42, 0.8)",
-  cardBorder: "rgba(148, 163, 184, 0.2)",
-  accent: "#38bdf8",
-  accentSoft: "rgba(56, 189, 248, 0.2)",
-  positive: "#22c55e",
-  warning: "#f97316",
-  danger: "#ef4444",
-  textPrimary: "#f8fafc",
-  textSecondary: "#cbd5f5",
+  background: "var(--color-surface-strong)",
+  card: "var(--color-surface-strong)",
+  cardBorder: "var(--color-border)",
+  accent: "var(--color-accent)",
+  accentSoft: "var(--color-accent-soft)",
+  accentContrast: "var(--color-accent-contrast)",
+  positive: "var(--color-positive)",
+  warning: "var(--color-warning)",
+  danger: "var(--color-danger)",
+  textPrimary: "var(--color-foreground)",
+  textSecondary: "var(--color-text-secondary)",
 };
 
 export const shadows = {
-  soft: "0 10px 50px rgba(15, 23, 42, 0.35)",
+  soft: "var(--shadow-soft)",
 };
 
 export const transitions = {

--- a/app/listing/[id]/page.js
+++ b/app/listing/[id]/page.js
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import clsx from "clsx";
 import Link from "next/link";
 import Image from "next/image";
 import { useParams } from "next/navigation";
@@ -180,13 +181,13 @@ export default function ListingPage() {
   }
 
   if (!id) return <div className="p-5">Invalid listing id</div>;
-  if (loading) return <div className="p-5 text-sm text-foreground/60">Loading…</div>;
-  if (error) return <div className="p-5 text-sm text-red-500">{error}</div>;
-  if (!listing?.ok) return <div className="p-5 text-sm text-foreground/60">Not found.</div>;
+  if (loading) return <div className="p-5 text-sm text-[color:var(--color-text-secondary)]">Loading…</div>;
+  if (error) return <div className="p-5 text-sm text-[color:var(--color-danger)]">{error}</div>;
+  if (!listing?.ok) return <div className="p-5 text-sm text-[color:var(--color-text-secondary)]">Not found.</div>;
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex items-center justify-between text-xs text-foreground/60">
+      <div className="flex items-center justify-between text-xs text-[color:var(--color-text-secondary)]">
         <Link href="/" className="inline-flex items-center gap-1 text-sm underline">
           ← Back to create
         </Link>
@@ -195,14 +196,14 @@ export default function ListingPage() {
 
       <div className="grid gap-6 lg:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)]">
         <section className="space-y-4">
-          <div id="description" className="rounded-2xl border border-black/10 bg-black/5 p-5 dark:border-white/15 dark:bg-white/5">
+          <div id="description" className="rounded-2xl border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)] p-5">
             <div className="flex items-center justify-between">
               <h2 className="text-lg font-semibold">Generated gallery</h2>
               {activeImage && (
                 <button
                   type="button"
                   onClick={() => openViewer(activeImageIndex)}
-                  className="inline-flex items-center gap-1 rounded-full border border-foreground/20 px-3 py-1 text-xs"
+                  className="inline-flex items-center gap-1 rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-surface)] px-3 py-1 text-xs transition hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-surface-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-background)]"
                 >
                   <Maximize2 className="size-3" />
                   View full
@@ -212,7 +213,7 @@ export default function ListingPage() {
             <div className="mt-4">
               {activeImage ? (
                 <div className="flex flex-col gap-3">
-                  <div className="relative overflow-hidden rounded-2xl border border-foreground/15 bg-background/40">
+                <div className="relative overflow-hidden rounded-2xl border border-[color:var(--color-border)] bg-[color:var(--color-surface)]">
                     <div className="aspect-[4/5] w-full">
                       <Image
                         src={activeImage.url}
@@ -224,21 +225,27 @@ export default function ListingPage() {
                       />
                     </div>
                     {!activeIsSource && listing.cover_s3_key === activeKey && (
-                      <span className="absolute left-3 top-3 rounded-full border border-foreground/20 bg-background/80 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide">
+                      <span className="absolute left-3 top-3 rounded-full border border-[color:var(--color-border-muted)] bg-[color:var(--color-surface-strong)] px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-[color:var(--color-text-secondary)]">
                         Cover
                       </span>
                     )}
                   </div>
                   <div className="flex flex-wrap items-center gap-2 text-xs">
-                    <span className="rounded-full border border-foreground/15 px-3 py-1">{activeIsSource ? "Source garment" : activeImage.pose || "image"}</span>
+                    <span className="rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-surface)] px-3 py-1 text-[color:var(--color-text-secondary)]">
+                      {activeIsSource ? "Source garment" : activeImage.pose || "image"}
+                    </span>
                     {activeKey && (
                       <button
                         type="button"
                         onClick={() => setCover(activeKey)}
                         disabled={settingCover || listing.cover_s3_key === activeKey}
-                        className={`rounded-full border px-3 py-1 font-medium ${
-                          listing.cover_s3_key === activeKey ? "border-foreground bg-foreground/10" : "border-foreground/20"
-                        } ${settingCover ? "opacity-60" : ""}`}
+                        className={clsx(
+                          "rounded-full border px-3 py-1 font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-background)]",
+                          listing.cover_s3_key === activeKey
+                            ? "border-[color:var(--color-accent)] bg-[color:var(--color-accent)] text-[color:var(--color-accent-contrast)]"
+                            : "border-[color:var(--color-border)] bg-[color:var(--color-surface)] text-[color:var(--color-text-secondary)] hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-surface-strong)]",
+                          settingCover ? "opacity-60" : ""
+                        )}
                       >
                         {listing.cover_s3_key === activeKey ? "Current cover" : "Set as cover"}
                       </button>
@@ -247,20 +254,20 @@ export default function ListingPage() {
                       <button
                         type="button"
                         onClick={() => togglePromptFor(activeKey)}
-                        className="rounded-full border border-foreground/20 px-3 py-1 font-medium"
+                        className="rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-surface)] px-3 py-1 font-medium text-[color:var(--color-text-secondary)] transition hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-surface-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-background)]"
                       >
                         {activePromptVisible ? "Hide prompt" : "Show prompt"}
                       </button>
                     )}
                   </div>
                   {!activeIsSource && activePromptVisible && (
-                    <pre className="max-h-48 overflow-auto rounded-xl border border-foreground/15 bg-background/50 p-4 text-xs leading-relaxed">
+                    <pre className="max-h-48 overflow-auto rounded-xl border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)] p-4 text-xs leading-relaxed text-[color:var(--color-text-secondary)]">
                       {activeImage.prompt || "No prompt stored."}
                     </pre>
                   )}
                 </div>
               ) : (
-                <div className="flex aspect-[4/5] items-center justify-center rounded-2xl border border-dashed border-foreground/20 text-sm text-foreground/60">
+                <div className="flex aspect-[4/5] items-center justify-center rounded-2xl border border-dashed border-[color:var(--color-border)] text-sm text-[color:var(--color-text-secondary)]">
                   No images generated yet.
                 </div>
               )}
@@ -274,18 +281,21 @@ export default function ListingPage() {
                     key={key}
                     type="button"
                     onClick={() => setActiveImageIndex(index)}
-                    className={`relative h-24 w-20 flex-shrink-0 overflow-hidden rounded-xl border ${
-                      index === activeImageIndex ? "border-foreground" : "border-foreground/20"
-                    }`}
+                    className={clsx(
+                      "relative h-24 w-20 flex-shrink-0 overflow-hidden rounded-xl border transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-background)]",
+                      index === activeImageIndex
+                        ? "border-[color:var(--color-accent)]"
+                        : "border-[color:var(--color-border)] hover:border-[color:var(--color-border-strong)]"
+                    )}
                     title={label}
                   >
                     {img.url ? (
                       <Image src={img.url} alt={label} fill sizes="80px" className="object-cover" />
                     ) : (
-                      <div className="h-full w-full bg-foreground/10" />
+                      <div className="h-full w-full bg-[color:var(--color-surface)]" />
                     )}
                     {isSourceImage(img) && (
-                      <span className="absolute left-1 top-1 rounded-full bg-background/80 px-1.5 py-0.5 text-[10px] uppercase">
+                      <span className="absolute left-1 top-1 rounded-full bg-[color:var(--color-surface-strong)] px-1.5 py-0.5 text-[10px] uppercase text-[color:var(--color-text-secondary)]">
                         Source
                       </span>
                     )}
@@ -297,18 +307,33 @@ export default function ListingPage() {
         </section>
 
         <aside className="space-y-4">
-          <div className="rounded-2xl border border-black/10 bg-black/5 p-5 text-sm dark:border-white/15 dark:bg-white/5">
+          <div className="rounded-2xl border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)] p-5 text-sm">
             <h3 className="text-sm font-semibold">Listing settings</h3>
-            <dl className="mt-3 grid gap-2 text-xs text-foreground/70">
-              <div className="flex justify-between gap-2"><dt className="font-medium text-foreground/80">Gender</dt><dd>{settings.gender || "–"}</dd></div>
-              <div className="flex justify-between gap-2"><dt className="font-medium text-foreground/80">Environment</dt><dd>{settings.environment || "–"}</dd></div>
-              <div className="flex justify-between gap-2"><dt className="font-medium text-foreground/80">Garment type</dt><dd>{settings.garment_type || "auto"}</dd></div>
-              <div className="flex justify-between gap-2"><dt className="font-medium text-foreground/80">Poses</dt><dd>{Array.isArray(settings.poses) && settings.poses.length ? settings.poses.join(", ") : "–"}</dd></div>
-              <div><dt className="font-medium text-foreground/80">Notes</dt><dd className="mt-1 text-foreground/60">{settings.extra || "–"}</dd></div>
+            <dl className="mt-3 grid gap-2 text-xs text-[color:var(--color-text-secondary)]">
+              <div className="flex justify-between gap-2">
+                <dt className="font-medium text-[color:var(--color-foreground)]">Gender</dt>
+                <dd>{settings.gender || "–"}</dd>
+              </div>
+              <div className="flex justify-between gap-2">
+                <dt className="font-medium text-[color:var(--color-foreground)]">Environment</dt>
+                <dd>{settings.environment || "–"}</dd>
+              </div>
+              <div className="flex justify-between gap-2">
+                <dt className="font-medium text-[color:var(--color-foreground)]">Garment type</dt>
+                <dd>{settings.garment_type || "auto"}</dd>
+              </div>
+              <div className="flex justify-between gap-2">
+                <dt className="font-medium text-[color:var(--color-foreground)]">Poses</dt>
+                <dd>{Array.isArray(settings.poses) && settings.poses.length ? settings.poses.join(", ") : "–"}</dd>
+              </div>
+              <div>
+                <dt className="font-medium text-[color:var(--color-foreground)]">Notes</dt>
+                <dd className="mt-1">{settings.extra || "–"}</dd>
+              </div>
             </dl>
           </div>
 
-          <div id="description" className="rounded-2xl border border-black/10 bg-black/5 p-5 dark:border-white/15 dark:bg-white/5">
+          <div id="description" className="rounded-2xl border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)] p-5">
             <div className="flex items-center justify-between">
               <h3 className="text-sm font-semibold">Description</h3>
               {hasDescription && (
@@ -326,21 +351,25 @@ export default function ListingPage() {
                 </button>
               )}
             </div>
-            <div className="mt-3 space-y-3 rounded-xl border border-foreground/15 bg-background/40 p-4">
-              <div className="flex items-center justify-between text-xs text-foreground/70">
+            <div className="mt-3 space-y-3 rounded-xl border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-4">
+              <div className="flex items-center justify-between text-xs text-[color:var(--color-text-secondary)]">
                 <span>Include product details</span>
                 <button
                   type="button"
                   onClick={() => setDescEnabled((v) => !v)}
-                  className={`relative inline-flex h-6 w-12 items-center rounded-full transition ${
-                    descEnabled ? "bg-foreground" : "bg-foreground/30"
-                  }`}
+                  className={clsx(
+                    "relative inline-flex h-6 w-12 items-center rounded-full border transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-background)]",
+                    descEnabled
+                      ? "border-transparent bg-[color:var(--color-accent)]"
+                      : "border-[color:var(--color-border)] bg-[color:var(--color-surface)]"
+                  )}
                   aria-pressed={descEnabled}
                 >
                   <span
-                    className={`inline-block h-5 w-5 transform rounded-full bg-background transition ${
+                    className={clsx(
+                      "inline-block h-5 w-5 transform rounded-full bg-[color:var(--color-background)] shadow transition",
                       descEnabled ? "translate-x-6" : "translate-x-1"
-                    }`}
+                    )}
                   />
                 </button>
               </div>
@@ -348,14 +377,14 @@ export default function ListingPage() {
                 <div className="grid grid-cols-2 gap-2 text-sm">
                   <input
                     type="text"
-                    className="col-span-2 h-9 rounded-lg border border-foreground/15 bg-background/60 px-3"
+                    className="col-span-2 h-9 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] px-3 focus:outline-none focus:ring-2 focus:ring-[color:var(--color-accent)] focus:ring-offset-2 focus:ring-offset-[color:var(--color-background)]"
                     placeholder="Brand (e.g., Nike, Zara)"
                     value={desc.brand}
                     onChange={(e) => setDesc((d) => ({ ...d, brand: e.target.value }))}
                   />
                   <input
                     type="text"
-                    className="col-span-2 h-9 rounded-lg border border-foreground/15 bg-background/60 px-3"
+                    className="col-span-2 h-9 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] px-3 focus:outline-none focus:ring-2 focus:ring-[color:var(--color-accent)] focus:ring-offset-2 focus:ring-offset-[color:var(--color-background)]"
                     placeholder="Model (e.g., Air Max 90)"
                     value={desc.productModel}
                     onChange={(e) => setDesc((d) => ({ ...d, productModel: e.target.value }))}
@@ -366,9 +395,12 @@ export default function ListingPage() {
                         key={condition}
                         type="button"
                         onClick={() => setProductCondition(condition)}
-                        className={`h-8 rounded-full border px-3 text-xs ${
-                          productCondition === condition ? "border-foreground" : "border-foreground/20"
-                        }`}
+                        className={clsx(
+                          "h-8 rounded-full border px-3 text-xs transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-background)]",
+                          productCondition === condition
+                            ? "border-[color:var(--color-accent)] bg-[color:var(--color-accent)] text-[color:var(--color-accent-contrast)]"
+                            : "border-[color:var(--color-border)] bg-[color:var(--color-surface)] text-[color:var(--color-text-secondary)] hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-surface-strong)]"
+                        )}
                       >
                         {condition}
                       </button>
@@ -380,9 +412,12 @@ export default function ListingPage() {
                         key={size}
                         type="button"
                         onClick={() => setDesc((d) => ({ ...d, size }))}
-                        className={`h-8 rounded-full border px-3 text-xs uppercase ${
-                          desc.size === size ? "border-foreground" : "border-foreground/20"
-                        }`}
+                        className={clsx(
+                          "h-8 rounded-full border px-3 text-xs uppercase transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-background)]",
+                          desc.size === size
+                            ? "border-[color:var(--color-accent)] bg-[color:var(--color-accent)] text-[color:var(--color-accent-contrast)]"
+                            : "border-[color:var(--color-border)] bg-[color:var(--color-surface)] text-[color:var(--color-text-secondary)] hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-surface-strong)]"
+                        )}
                       >
                         {size}
                       </button>
@@ -393,28 +428,34 @@ export default function ListingPage() {
             </div>
             {hasDescription ? (
               <>
-                <pre className="mt-3 whitespace-pre-wrap rounded-xl border border-foreground/15 bg-background/40 p-4 text-sm leading-relaxed">
+                <pre className="mt-3 whitespace-pre-wrap rounded-xl border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-4 text-sm leading-relaxed text-[color:var(--color-text-secondary)]">
                   {listing.description_text}
                 </pre>
                 <button
                   type="button"
                   onClick={generateDescription}
                   disabled={genDescLoading}
-                  className={`mt-3 h-9 w-full rounded-lg border border-foreground/20 px-3 text-sm font-semibold ${
-                    genDescLoading ? "opacity-60" : ""
+                  className={`mt-3 h-9 w-full rounded-lg px-3 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-background)] ${
+                    genDescLoading
+                      ? "bg-[color:var(--color-accent)]/60 text-[color:var(--color-accent-contrast)]/80"
+                      : "bg-[color:var(--color-accent)] text-[color:var(--color-accent-contrast)]"
                   }`}
                 >
                   {genDescLoading ? "Regenerating…" : "Regenerate description"}
                 </button>
               </>
             ) : (
-              <div className="mt-3 flex flex-col gap-2 text-xs text-foreground/60">
+              <div className="mt-3 flex flex-col gap-2 text-xs text-[color:var(--color-text-secondary)]">
                 <p>No description generated.</p>
                 <button
                   type="button"
                   onClick={generateDescription}
                   disabled={genDescLoading}
-                  className={`h-9 w-full rounded-lg border border-foreground/20 px-3 text-sm font-semibold ${genDescLoading ? "opacity-60" : ""}`}
+                  className={`h-9 w-full rounded-lg px-3 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-background)] ${
+                    genDescLoading
+                      ? "bg-[color:var(--color-accent)]/60 text-[color:var(--color-accent-contrast)]/80"
+                      : "bg-[color:var(--color-accent)] text-[color:var(--color-accent-contrast)]"
+                  }`}
                 >
                   {genDescLoading ? "Generating…" : "Generate description"}
                 </button>
@@ -425,11 +466,11 @@ export default function ListingPage() {
       </div>
 
       {viewerOpen && galleryImages.length > 0 && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-[color:var(--color-overlay)] p-4">
           <button
             type="button"
             onClick={closeViewer}
-            className="absolute right-4 top-4 rounded-full border border-white/20 p-2 text-white"
+            className="absolute right-4 top-4 rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-2 text-[color:var(--color-foreground)] transition hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-surface-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)]"
             aria-label="Close viewer"
           >
             <XIcon className="size-4" />
@@ -437,7 +478,7 @@ export default function ListingPage() {
           <button
             type="button"
             onClick={handleViewerPrev}
-            className="absolute left-4 top-1/2 grid size-10 -translate-y-1/2 place-items-center rounded-full border border-white/20 text-white"
+            className="absolute left-4 top-1/2 grid size-10 -translate-y-1/2 place-items-center rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-surface)] text-[color:var(--color-foreground)] transition hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-surface-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)]"
             aria-label="Previous image"
           >
             <ChevronLeft className="size-5" />
@@ -445,12 +486,12 @@ export default function ListingPage() {
           <button
             type="button"
             onClick={handleViewerNext}
-            className="absolute right-4 top-1/2 grid size-10 -translate-y-1/2 place-items-center rounded-full border border-white/20 text-white"
+            className="absolute right-4 top-1/2 grid size-10 -translate-y-1/2 place-items-center rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-surface)] text-[color:var(--color-foreground)] transition hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-surface-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)]"
             aria-label="Next image"
           >
             <ChevronRight className="size-5" />
           </button>
-          <div className="max-h-[85vh] max-w-[90vw] overflow-hidden rounded-2xl border border-white/20 bg-black/40 p-4">
+          <div className="max-h-[85vh] max-w-[90vw] overflow-hidden rounded-2xl border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)] p-4">
             {viewerImage ? (
               <>
                 <div className="relative mx-auto aspect-[4/5] w-[min(70vw,420px)]">
@@ -461,21 +502,21 @@ export default function ListingPage() {
                     sizes="(max-width: 1024px) 80vw, 400px"
                     className="object-contain"
                   />
-                  <span className="absolute left-3 top-3 rounded-full border border-white/30 bg-black/60 px-3 py-1 text-xs uppercase text-white">
+                  <span className="absolute left-3 top-3 rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-surface)] px-3 py-1 text-xs uppercase text-[color:var(--color-text-secondary)]">
                     {viewerIsSource ? "source garment" : viewerImage.pose || "image"}
                   </span>
                 </div>
                 {!viewerIsSource && viewerPromptVisible && (
-                  <pre className="mt-3 max-h-48 overflow-auto rounded-xl border border-white/20 bg-black/60 p-4 text-xs text-white">
+                  <pre className="mt-3 max-h-48 overflow-auto rounded-xl border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-4 text-xs text-[color:var(--color-text-secondary)]">
                     {viewerImage.prompt || "No prompt stored."}
                   </pre>
                 )}
-                <div className="mt-3 flex items-center gap-2 text-xs text-white/80">
+                <div className="mt-3 flex items-center gap-2 text-xs text-[color:var(--color-text-secondary)]">
                   {!viewerIsSource && viewerKey && (
                     <button
                       type="button"
                       onClick={() => togglePromptFor(viewerKey)}
-                      className="rounded-full border border-white/30 px-3 py-1"
+                      className="rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-surface)] px-3 py-1 transition hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-surface-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)]"
                     >
                       {viewerPromptVisible ? "Hide prompt" : "Show prompt"}
                     </button>

--- a/app/listings/page.js
+++ b/app/listings/page.js
@@ -96,12 +96,14 @@ export default function ListingsPage() {
       <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Your listings</h1>
-          <p className="text-sm text-foreground/70">Browse every generated listing, tweak covers, and jump back into edits.</p>
+          <p className="text-sm text-[color:var(--color-text-secondary)]">
+            Browse every generated listing, tweak covers, and jump back into edits.
+          </p>
         </div>
         <div className="flex items-center gap-2">
           <Link
             href="/"
-            className="inline-flex h-9 items-center justify-center gap-1 rounded-lg bg-foreground px-3 text-xs font-semibold text-background"
+            className="inline-flex h-9 items-center justify-center gap-1 rounded-lg bg-[color:var(--color-accent)] px-3 text-xs font-semibold text-[color:var(--color-accent-contrast)] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-background)]"
           >
             <Plus className="size-3" />
             New listing
@@ -110,13 +112,13 @@ export default function ListingsPage() {
       </div>
 
       {!userId ? (
-        <div className="rounded-2xl border border-black/10 bg-black/5 p-6 text-sm text-foreground/70 dark:border-white/15 dark:bg-white/5">
+        <div className="rounded-2xl border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)] p-6 text-sm text-[color:var(--color-text-secondary)]">
           Sign in to view your listings.
         </div>
       ) : loading ? (
         <div className="grid gap-4 sm:grid-cols-2">
           {Array.from({ length: 4 }).map((_, idx) => (
-            <div key={idx} className="h-36 animate-pulse rounded-2xl bg-foreground/10" />
+            <div key={idx} className="h-36 animate-pulse rounded-2xl bg-[color:var(--color-surface)]" />
           ))}
         </div>
       ) : error ? (
@@ -124,7 +126,7 @@ export default function ListingsPage() {
           {error}
         </div>
       ) : sortedListings.length === 0 ? (
-        <div className="rounded-2xl border border-black/10 bg-black/5 p-6 text-sm text-foreground/70 dark:border-white/15 dark:bg-white/5">
+        <div className="rounded-2xl border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)] p-6 text-sm text-[color:var(--color-text-secondary)]">
           No listings yet. Generate your first one to see it here.
         </div>
       ) : (
@@ -136,26 +138,30 @@ export default function ListingsPage() {
               <Link
                 key={listing.id}
                 href={`/listing/${listing.id}`}
-                className="group flex flex-col gap-3 rounded-2xl border border-black/10 bg-black/5 p-4 text-sm transition hover:border-foreground/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground dark:border-white/15 dark:bg-white/5"
+                className="group flex flex-col gap-3 rounded-2xl border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)] p-4 text-sm transition hover:border-[color:var(--color-border-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-background)]"
               >
                 <div className="flex items-center gap-3">
-                  <div className="relative h-20 w-20 flex-shrink-0 overflow-hidden rounded-xl border border-foreground/15 bg-background/40">
+                  <div className="relative h-20 w-20 flex-shrink-0 overflow-hidden rounded-xl border border-[color:var(--color-border)] bg-[color:var(--color-surface)]">
                     {listing.cover_url ? (
                       <Image src={listing.cover_url} alt={listing.title || "Listing cover"} fill sizes="80px" className="object-cover" />
                     ) : (
-                      <div className="flex h-full w-full items-center justify-center text-[11px] text-foreground/50">No cover</div>
+                      <div className="flex h-full w-full items-center justify-center text-[11px] text-[color:var(--color-text-tertiary)]">
+                        No cover
+                      </div>
                     )}
                   </div>
                   <div className="min-w-0 flex-1">
-                    <p className="truncate text-sm font-semibold text-foreground">{listing.title || "Untitled listing"}</p>
+                    <p className="truncate text-sm font-semibold text-[color:var(--color-foreground)]">{listing.title || "Untitled listing"}</p>
                     {createdAt && (
-                      <p className="text-xs text-foreground/60">{createdAt.toLocaleString()}</p>
+                      <p className="text-xs text-[color:var(--color-text-secondary)]">{createdAt.toLocaleString()}</p>
                     )}
-                    <p className="mt-1 text-[11px] uppercase tracking-wide text-foreground/50">
+                    <p className="mt-1 text-[11px] uppercase tracking-wide text-[color:var(--color-text-tertiary)]">
                       {settings.gender || ""} {settings.environment || ""}
                     </p>
                     {typeof listing.images_count === "number" && (
-                      <p className="text-[11px] text-foreground/60">{listing.images_count} image{listing.images_count === 1 ? "" : "s"}</p>
+                      <p className="text-[11px] text-[color:var(--color-text-secondary)]">
+                        {listing.images_count} image{listing.images_count === 1 ? "" : "s"}
+                      </p>
                     )}
                   </div>
                 </div>
@@ -166,7 +172,9 @@ export default function ListingsPage() {
       )}
 
       {isAdmin && (
-        <p className="text-center text-[11px] text-foreground/40">Admin? Use the init tools on the Create page to seed defaults.</p>
+        <p className="text-center text-[11px] text-[color:var(--color-text-tertiary)]">
+          Admin? Use the init tools on the Create page to seed defaults.
+        </p>
       )}
     </div>
   );

--- a/app/settings/page.js
+++ b/app/settings/page.js
@@ -40,29 +40,33 @@ export default function SettingsPage() {
     <div className="flex flex-col gap-6">
       <header>
         <h1 className="text-2xl font-semibold tracking-tight">Account settings</h1>
-        <p className="mt-1 text-sm text-foreground/70">
+        <p className="mt-1 text-sm text-[color:var(--color-text-secondary)]">
           Update your account details or sign out. More controls are coming soon.
         </p>
       </header>
 
-      <section className="rounded-2xl border border-black/10 bg-black/5 p-5 dark:border-white/15 dark:bg-white/5">
+      <section className="rounded-2xl border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)] p-5">
         <h2 className="text-lg font-semibold">Email</h2>
-        <p className="mt-1 text-xs text-foreground/60">Keep your contact email up to date.</p>
+        <p className="mt-1 text-xs text-[color:var(--color-text-secondary)]">Keep your contact email up to date.</p>
         <form onSubmit={handleEmailSubmit} className="mt-4 flex flex-col gap-3 sm:max-w-md">
-          <label className="text-xs text-foreground/70" htmlFor="settings-email">Email address</label>
+          <label className="text-xs text-[color:var(--color-text-secondary)]" htmlFor="settings-email">
+            Email address
+          </label>
           <input
             id="settings-email"
             type="email"
             value={email}
             onChange={(event) => setEmail(event.target.value)}
-            className="h-10 w-full rounded-lg border border-foreground/15 bg-background/40 px-3 text-sm"
+            className="h-10 w-full rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] px-3 text-sm focus:outline-none focus:ring-2 focus:ring-[color:var(--color-accent)] focus:ring-offset-2 focus:ring-offset-[color:var(--color-background)]"
             placeholder="you@example.com"
           />
           <button
             type="submit"
             disabled={busy}
-            className={`inline-flex h-10 items-center justify-center rounded-lg px-4 text-sm font-semibold ${
-              busy ? "bg-foreground/30 text-background/60" : "bg-foreground text-background"
+            className={`inline-flex h-10 items-center justify-center rounded-lg px-4 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-background)] ${
+              busy
+                ? "bg-[color:var(--color-accent)]/60 text-[color:var(--color-accent-contrast)]/80"
+                : "bg-[color:var(--color-accent)] text-[color:var(--color-accent-contrast)]"
             }`}
           >
             Save email
@@ -70,42 +74,50 @@ export default function SettingsPage() {
         </form>
       </section>
 
-      <section className="rounded-2xl border border-black/10 bg-black/5 p-5 dark:border-white/15 dark:bg-white/5">
+      <section className="rounded-2xl border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)] p-5">
         <h2 className="text-lg font-semibold">Password</h2>
-        <p className="mt-1 text-xs text-foreground/60">Change your password to keep your account secure.</p>
+        <p className="mt-1 text-xs text-[color:var(--color-text-secondary)]">Change your password to keep your account secure.</p>
         <form onSubmit={handlePasswordSubmit} className="mt-4 flex flex-col gap-3 sm:max-w-md">
-          <label className="text-xs text-foreground/70" htmlFor="current-password">Current password</label>
+          <label className="text-xs text-[color:var(--color-text-secondary)]" htmlFor="current-password">
+            Current password
+          </label>
           <input
             id="current-password"
             type="password"
             value={passwords.current}
             onChange={(event) => setPasswords((prev) => ({ ...prev, current: event.target.value }))}
-            className="h-10 w-full rounded-lg border border-foreground/15 bg-background/40 px-3 text-sm"
+            className="h-10 w-full rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] px-3 text-sm focus:outline-none focus:ring-2 focus:ring-[color:var(--color-accent)] focus:ring-offset-2 focus:ring-offset-[color:var(--color-background)]"
             placeholder="••••••••"
           />
-          <label className="text-xs text-foreground/70" htmlFor="new-password">New password</label>
+          <label className="text-xs text-[color:var(--color-text-secondary)]" htmlFor="new-password">
+            New password
+          </label>
           <input
             id="new-password"
             type="password"
             value={passwords.next}
             onChange={(event) => setPasswords((prev) => ({ ...prev, next: event.target.value }))}
-            className="h-10 w-full rounded-lg border border-foreground/15 bg-background/40 px-3 text-sm"
+            className="h-10 w-full rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] px-3 text-sm focus:outline-none focus:ring-2 focus:ring-[color:var(--color-accent)] focus:ring-offset-2 focus:ring-offset-[color:var(--color-background)]"
             placeholder="••••••••"
           />
-          <label className="text-xs text-foreground/70" htmlFor="confirm-password">Confirm new password</label>
+          <label className="text-xs text-[color:var(--color-text-secondary)]" htmlFor="confirm-password">
+            Confirm new password
+          </label>
           <input
             id="confirm-password"
             type="password"
             value={passwords.confirm}
             onChange={(event) => setPasswords((prev) => ({ ...prev, confirm: event.target.value }))}
-            className="h-10 w-full rounded-lg border border-foreground/15 bg-background/40 px-3 text-sm"
+            className="h-10 w-full rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] px-3 text-sm focus:outline-none focus:ring-2 focus:ring-[color:var(--color-accent)] focus:ring-offset-2 focus:ring-offset-[color:var(--color-background)]"
             placeholder="••••••••"
           />
           <button
             type="submit"
             disabled={busy}
-            className={`inline-flex h-10 items-center justify-center rounded-lg px-4 text-sm font-semibold ${
-              busy ? "bg-foreground/30 text-background/60" : "bg-foreground text-background"
+            className={`inline-flex h-10 items-center justify-center rounded-lg px-4 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-background)] ${
+              busy
+                ? "bg-[color:var(--color-accent)]/60 text-[color:var(--color-accent-contrast)]/80"
+                : "bg-[color:var(--color-accent)] text-[color:var(--color-accent-contrast)]"
             }`}
           >
             Save password

--- a/app/studio/admin/page.js
+++ b/app/studio/admin/page.js
@@ -1,7 +1,8 @@
 "use client";
 export const dynamic = "force-dynamic";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import clsx from "clsx";
 import { createAuthClient } from "better-auth/react";
 import { getApiBase } from "@/app/lib/api";
 import { getSessionBasics } from "@/app/lib/session";
@@ -17,7 +18,7 @@ export default function StudioAdminPage() {
     return (
       <div className="max-w-md mx-auto p-6">
         <h1 className="text-lg font-semibold mb-2">Admin only</h1>
-        <p className="text-sm text-gray-500">You don’t have access to the Studio admin console.</p>
+        <p className="text-sm text-[color:var(--color-text-secondary)]">You don’t have access to the Studio admin console.</p>
         <a href="/studio" className="inline-block mt-4 underline">Back to Studio</a>
       </div>
     );
@@ -37,7 +38,12 @@ export default function StudioAdminPage() {
               key={t.k}
               type="button"
               onClick={() => setActive(t.k)}
-              className={`h-8 px-3 rounded-md border ${active === t.k ? 'bg-foreground text-background' : ''}`}
+              className={clsx(
+                "h-8 px-3 rounded-md border border-[color:var(--color-border)] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-background)]",
+                active === t.k
+                  ? "bg-[color:var(--color-accent)] text-[color:var(--color-accent-contrast)]"
+                  : "text-[color:var(--color-text-secondary)] hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-surface)]"
+              )}
             >
               {t.label}
             </button>
@@ -96,15 +102,31 @@ function EnvAdmin() {
   return (
     <section className="flex flex-col gap-3">
       <h2 className="text-base font-semibold">Environment Sources</h2>
-      <p className="text-sm text-gray-500">Upload source photos used to generate environment defaults.</p>
+      <p className="text-sm text-[color:var(--color-text-secondary)]">Upload source photos used to generate environment defaults.</p>
       <input type="file" multiple accept="image/*" onChange={(e) => setFiles(Array.from(e.target.files || []))} />
       <div className="flex items-center gap-2">
-        <button disabled={!files.length || busy} onClick={upload} className={`h-9 px-3 rounded-md border ${busy ? 'opacity-60' : ''}`}>Upload</button>
-        <button onClick={clearAll} className="h-9 px-3 rounded-md border">Delete all</button>
+        <button
+          disabled={!files.length || busy}
+          onClick={upload}
+          className={clsx(
+            "h-9 px-3 rounded-md border border-[color:var(--color-border)] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)]",
+            busy
+              ? "bg-[color:var(--color-accent)]/60 text-[color:var(--color-accent-contrast)]/80"
+              : "bg-[color:var(--color-accent)] text-[color:var(--color-accent-contrast)]"
+          )}
+        >
+          Upload
+        </button>
+        <button
+          onClick={clearAll}
+          className="h-9 px-3 rounded-md border border-[color:var(--color-border)] text-[color:var(--color-text-secondary)] transition hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-surface)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)]"
+        >
+          Delete all
+        </button>
       </div>
       <div className="grid grid-cols-6 gap-2">
         {sources.map((k) => (
-          <div key={k} className="aspect-[3/4] rounded border border-black/10 dark:border-white/15 text-[10px] p-1 break-all">{k.split('/').pop()}</div>
+          <div key={k} className="aspect-[3/4] rounded border border-[color:var(--color-border)] text-[10px] p-1 break-all">{k.split('/').pop()}</div>
         ))}
       </div>
     </section>
@@ -117,15 +139,17 @@ function ModelSourcesAdmin() {
   const [busy, setBusy] = useState(false);
   const [items, setItems] = useState([]);
 
-  async function refresh() {
+  const refresh = useCallback(async () => {
     try {
       const base = getApiBase();
       const res = await fetch(`${base}/model/sources?gender=${gender}`);
       const data = await res.json();
       setItems(data?.items || []);
     } catch {}
-  }
-  useEffect(() => { refresh(); }, [gender]);
+  }, [gender]);
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
 
   async function upload() {
     if (!files.length) return;
@@ -150,20 +174,35 @@ function ModelSourcesAdmin() {
     <section className="flex flex-col gap-3">
       <h2 className="text-base font-semibold">Model Sources</h2>
       <div className="flex items-center gap-2">
-        <label className="text-sm">Gender</label>
-        <select value={gender} onChange={(e) => setGender(e.target.value)} className="h-9 rounded border bg-transparent px-2">
+        <label className="text-sm text-[color:var(--color-text-secondary)]">Gender</label>
+        <select
+          value={gender}
+          onChange={(e) => setGender(e.target.value)}
+          className="h-9 rounded border border-[color:var(--color-border)] bg-transparent px-2 text-[color:var(--color-foreground)] focus:outline-none focus:ring-2 focus:ring-[color:var(--color-accent)]"
+        >
           <option value="man">Man</option>
           <option value="woman">Woman</option>
         </select>
       </div>
       <input type="file" multiple accept="image/*" onChange={(e) => setFiles(Array.from(e.target.files || []))} />
       <div className="flex items-center gap-2">
-        <button disabled={!files.length || busy} onClick={upload} className={`h-9 px-3 rounded-md border ${busy ? 'opacity-60' : ''}`}>Upload</button>
+        <button
+          disabled={!files.length || busy}
+          onClick={upload}
+          className={clsx(
+            "h-9 px-3 rounded-md border border-[color:var(--color-border)] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)]",
+            busy
+              ? "bg-[color:var(--color-accent)]/60 text-[color:var(--color-accent-contrast)]/80"
+              : "bg-[color:var(--color-accent)] text-[color:var(--color-accent-contrast)]"
+          )}
+        >
+          Upload
+        </button>
       </div>
       <div className="grid grid-cols-6 gap-2">
         {items.map((it) => (
-          <div key={it.s3_key} className="aspect-[3/4] rounded overflow-hidden border border-black/10 dark:border-white/15">
-            {it.url ? <img src={it.url} alt="source" className="w-full h-full object-cover" /> : <div className="w-full h-full bg-black/10 dark:bg-white/10" />}
+          <div key={it.s3_key} className="aspect-[3/4] rounded overflow-hidden border border-[color:var(--color-border)]">
+            {it.url ? <img src={it.url} alt="source" className="w-full h-full object-cover" /> : <div className="w-full h-full bg-[color:var(--color-surface)]" />}
           </div>
         ))}
       </div>
@@ -225,16 +264,43 @@ function PoseAdmin() {
   return (
     <section className="flex flex-col gap-3">
       <h2 className="text-base font-semibold">Poses</h2>
-      <p className="text-sm text-gray-500">Upload pose photos and generate pose-only descriptions for use in prompts.</p>
+      <p className="text-sm text-[color:var(--color-text-secondary)]">Upload pose photos and generate pose-only descriptions for use in prompts.</p>
       <input type="file" multiple accept="image/*" onChange={(e) => setFiles(Array.from(e.target.files || []))} />
       <div className="flex items-center gap-2">
-        <button disabled={!files.length || busy} onClick={upload} className={`h-9 px-3 rounded-md border ${busy ? 'opacity-60' : ''}`}>Upload</button>
-        <button disabled={descBusy} onClick={describeAll} className={`h-9 px-3 rounded-md border ${descBusy ? 'opacity-60' : ''}`}>Generate descriptions</button>
-        <button onClick={clearAll} className="h-9 px-3 rounded-md border">Delete all</button>
+        <button
+          disabled={!files.length || busy}
+          onClick={upload}
+          className={clsx(
+            "h-9 px-3 rounded-md border border-[color:var(--color-border)] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)]",
+            busy
+              ? "bg-[color:var(--color-accent)]/60 text-[color:var(--color-accent-contrast)]/80"
+              : "bg-[color:var(--color-accent)] text-[color:var(--color-accent-contrast)]"
+          )}
+        >
+          Upload
+        </button>
+        <button
+          disabled={descBusy}
+          onClick={describeAll}
+          className={clsx(
+            "h-9 px-3 rounded-md border border-[color:var(--color-border)] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)]",
+            descBusy
+              ? "bg-[color:var(--color-accent)]/60 text-[color:var(--color-accent-contrast)]/80"
+              : "bg-[color:var(--color-accent)] text-[color:var(--color-accent-contrast)]"
+          )}
+        >
+          Generate descriptions
+        </button>
+        <button
+          onClick={clearAll}
+          className="h-9 px-3 rounded-md border border-[color:var(--color-border)] text-[color:var(--color-text-secondary)] transition hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-surface)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)]"
+        >
+          Delete all
+        </button>
       </div>
       <div className="grid grid-cols-6 gap-2">
         {items.map((k) => (
-          <div key={k} className="aspect-[3/4] rounded border border-black/10 dark:border-white/15 text-[10px] p-1 break-all">{k.split('/').pop()}</div>
+          <div key={k} className="aspect-[3/4] rounded border border-[color:var(--color-border)] text-[10px] p-1 break-all">{k.split('/').pop()}</div>
         ))}
       </div>
     </section>

--- a/app/studio/page.js
+++ b/app/studio/page.js
@@ -461,18 +461,18 @@ export default function StudioPage() {
   const renderEnvironmentLibrary = () => {
     if (envLibraryView === "defaults") {
       if (defaults.length === 0) {
-        return <p className="text-xs text-foreground/60">You have no saved defaults yet. Promote generated scenes from the Generated tab.</p>;
+        return <p className="text-xs text-[color:var(--color-text-secondary)]">You have no saved defaults yet. Promote generated scenes from the Generated tab.</p>;
       }
       return (
         <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
           {defaults.map((item) => (
             <div
               key={item.s3_key}
-              className="group rounded-2xl border border-foreground/30 ring-2 ring-foreground/40 bg-background overflow-hidden shadow-sm"
+              className="group rounded-2xl border border-[color:var(--color-border-strong)] ring-2 ring-[color:var(--color-accent)] bg-[color:var(--color-surface)] overflow-hidden shadow-sm"
             >
-              <div className="relative aspect-[4/5] bg-black/5">
+              <div className="relative aspect-[4/5] bg-[color:var(--color-surface-strong)]">
                 <img src={item.url} alt={item.name || "Environment default"} className="h-full w-full object-cover" />
-                <div className="absolute left-3 top-3 inline-flex h-8 w-8 items-center justify-center rounded-full bg-blue-600/90 text-white">
+                <div className="absolute left-3 top-3 inline-flex h-8 w-8 items-center justify-center rounded-full bg-[color:var(--color-accent)] text-[color:var(--color-foreground)]">
                   <CheckCircle2 className="size-4" aria-hidden="true" />
                   <span className="sr-only">Default environment</span>
                 </div>
@@ -483,7 +483,7 @@ export default function StudioPage() {
                       if (!confirm("Remove this default?")) return;
                       await removeEnvDefault(item.s3_key);
                     }}
-                    className="inline-flex items-center gap-2 rounded-full bg-black/60 px-4 py-2 font-semibold text-white shadow hover:bg-black/70"
+                    className="inline-flex items-center gap-2 rounded-full bg-[color:var(--color-surface-strong)] px-4 py-2 font-semibold text-[color:var(--color-foreground)] shadow hover:bg-[color:var(--color-surface)]"
                   >
                     <Trash2 className="size-4" aria-hidden="true" />
                     Remove default
@@ -499,40 +499,40 @@ export default function StudioPage() {
     if (envLibraryView === "sources") {
       return (
         <div className="grid gap-6 lg:grid-cols-2">
-          <div className="rounded-2xl border border-black/10 bg-background p-5 dark:border-white/15 dark:bg-white/5">
+          <div className="rounded-2xl border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-5">
             <h4 className="text-sm font-semibold">Upload new sources</h4>
-            <p className="mt-1 text-xs text-foreground/60">Source environments help the generator learn your style.</p>
+            <p className="mt-1 text-xs text-[color:var(--color-text-secondary)]">Source environments help the generator learn your style.</p>
             <input
               type="file"
               accept="image/*"
               multiple
               onChange={handleBulkChange}
-              className="mt-3 block w-full text-sm file:mr-3 file:rounded-md file:border file:border-black/10 file:bg-transparent file:px-3 file:py-2 dark:file:border-white/15"
+              className="mt-3 block w-full text-sm file:mr-3 file:rounded-md file:border file:border-[color:var(--color-border)] file:bg-transparent file:px-3 file:py-2"
             />
             {bulkFiles.length > 0 && (
-              <div className="mt-3 flex items-center justify-between text-xs text-foreground/60">
+              <div className="mt-3 flex items-center justify-between text-xs text-[color:var(--color-text-secondary)]">
                 <span>{bulkFiles.length} file(s) selected</span>
                 <button
                   type="button"
                   onClick={handleBulkUpload}
-                  className="inline-flex h-9 items-center justify-center rounded-md bg-foreground px-3 font-semibold text-background"
+                  className="inline-flex h-9 items-center justify-center rounded-md bg-[color:var(--color-accent)] px-3 font-semibold text-[color:var(--color-accent-contrast)]"
                 >
                   Upload
                 </button>
               </div>
             )}
           </div>
-          <div className="rounded-2xl border border-black/10 bg-background p-5 dark:border-white/15 dark:bg-white/5">
+          <div className="rounded-2xl border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-5">
             <div className="flex items-center justify-between">
               <div>
                 <h4 className="text-sm font-semibold">Uploaded sources</h4>
-                <p className="mt-1 text-xs text-foreground/60">{sources.length} stored photo(s).</p>
+                <p className="mt-1 text-xs text-[color:var(--color-text-secondary)]">{sources.length} stored photo(s).</p>
               </div>
               <div className="flex items-center gap-2">
                 <button
                   type="button"
                   onClick={refreshSources}
-                  className="inline-flex h-8 items-center justify-center rounded-md border border-black/10 px-2 text-xs dark:border-white/15"
+                  className="inline-flex h-8 items-center justify-center rounded-md border border-[color:var(--color-border)] px-2 text-xs"
                 >
                   Refresh
                 </button>
@@ -548,9 +548,9 @@ export default function StudioPage() {
               </div>
             </div>
             {sources.length === 0 ? (
-              <p className="mt-3 text-xs text-foreground/60">No sources uploaded yet.</p>
+              <p className="mt-3 text-xs text-[color:var(--color-text-secondary)]">No sources uploaded yet.</p>
             ) : (
-              <ul className="mt-3 space-y-1 text-xs text-foreground/70">
+              <ul className="mt-3 space-y-1 text-xs text-[color:var(--color-text-secondary)]">
                 {sources.map((src) => (
                   <li key={src.s3_key} className="truncate">{src.s3_key}</li>
                 ))}
@@ -562,7 +562,7 @@ export default function StudioPage() {
     }
 
     if (generated.length === 0) {
-      return <p className="text-xs text-foreground/60">Generate a scene to see it listed here.</p>;
+      return <p className="text-xs text-[color:var(--color-text-secondary)]">Generate a scene to see it listed here.</p>;
     }
 
     return (
@@ -573,16 +573,16 @@ export default function StudioPage() {
           return (
             <div
               key={item.s3_key}
-              className={`group rounded-2xl border bg-background overflow-hidden transition ${
+              className={`group rounded-2xl border bg-[color:var(--color-surface)] overflow-hidden transition ${
                 isDefault
-                  ? "border-blue-500 ring-2 ring-blue-300 shadow-lg"
-                  : "border-foreground/15 hover:border-foreground/40"
+                  ? "border-[color:var(--color-accent)] ring-2 ring-[color:var(--color-accent)] shadow-lg"
+                  : "border-[color:var(--color-border)] hover:border-[color:var(--color-border-strong)]"
               }`}
             >
-              <div className="relative aspect-[3/4] md:aspect-[4/5] bg-black/5">
+              <div className="relative aspect-[3/4] md:aspect-[4/5] bg-[color:var(--color-surface-strong)]">
                 <img src={src} alt="Generated environment" className="h-full w-full object-cover" />
                 {isDefault && (
-                  <div className="absolute left-3 top-3 inline-flex h-8 w-8 items-center justify-center rounded-full bg-blue-600/90 text-white">
+                  <div className="absolute left-3 top-3 inline-flex h-8 w-8 items-center justify-center rounded-full bg-[color:var(--color-accent)] text-[color:var(--color-foreground)]">
                     <CheckCircle2 className="size-4" aria-hidden="true" />
                     <span className="sr-only">Default environment</span>
                   </div>
@@ -595,7 +595,7 @@ export default function StudioPage() {
                         if (!confirm("Remove this default?")) return;
                         await removeEnvDefault(item.s3_key);
                       }}
-                      className="inline-flex items-center gap-2 rounded-full bg-black/60 px-4 py-2 font-semibold text-white shadow hover:bg-black/70"
+                      className="inline-flex items-center gap-2 rounded-full bg-[color:var(--color-surface-strong)] px-4 py-2 font-semibold text-[color:var(--color-foreground)] shadow hover:bg-[color:var(--color-surface)]"
                     >
                       <MinusCircle className="size-4" aria-hidden="true" />
                       Remove default
@@ -606,7 +606,7 @@ export default function StudioPage() {
                       onClick={async () => {
                         await addEnvDefault(item.s3_key);
                       }}
-                      className="inline-flex items-center gap-2 rounded-full bg-blue-600 px-4 py-2 font-semibold text-white shadow hover:bg-blue-700"
+                      className="inline-flex items-center gap-2 rounded-full bg-[color:var(--color-accent)] px-4 py-2 font-semibold text-[color:var(--color-foreground)] shadow hover:bg-[color:var(--color-accent)]/90"
                     >
                       <PlusCircle className="size-4" aria-hidden="true" />
                       Add to default
@@ -614,7 +614,7 @@ export default function StudioPage() {
                   )}
                   <button
                     type="button"
-                    className="inline-flex items-center gap-2 rounded-full bg-red-600 px-4 py-2 font-semibold text-white shadow hover:bg-red-700"
+                    className="inline-flex items-center gap-2 rounded-full bg-red-600 px-4 py-2 font-semibold text-[color:var(--color-foreground)] shadow hover:bg-red-700"
                     onClick={async () => {
                       if (!confirm("Delete this image? This cannot be undone.")) return;
                       try {
@@ -643,15 +643,15 @@ export default function StudioPage() {
 
   const renderEnvironmentSection = () => (
     <div className="space-y-6">
-      <div className="rounded-2xl border border-black/10 bg-black/5 p-5 dark:border-white/15 dark:bg-white/5">
+      <div className="rounded-2xl border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)] p-5">
         <h3 className="text-lg font-semibold">Generate environment</h3>
-        <p className="mt-1 text-xs text-foreground/60">Describe a backdrop or leave blank for a random mirror scene.</p>
+        <p className="mt-1 text-xs text-[color:var(--color-text-secondary)]">Describe a backdrop or leave blank for a random mirror scene.</p>
         <textarea
           rows={4}
           value={prompt}
           onChange={(event) => setPrompt(event.target.value)}
           placeholder="e.g. sunlit loft apartment with a full-length mirror and wooden floors"
-          className="mt-3 w-full rounded-lg border border-black/10 bg-background/50 px-3 py-2 text-sm dark:border-white/15"
+          className="mt-3 w-full rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/50 px-3 py-2 text-sm"
         />
         <div className="mt-4 flex justify-center">
           <button
@@ -659,7 +659,7 @@ export default function StudioPage() {
             onClick={handleGenerate}
             disabled={isGenerating}
             className={`inline-flex h-12 w-full max-w-xs items-center justify-center rounded-xl px-6 text-base font-semibold ${
-              isGenerating ? "bg-foreground/30 text-background/60" : "bg-foreground text-background shadow"
+              isGenerating ? "bg-[color:var(--color-accent)]/60 text-[color:var(--color-accent-contrast)]/80" : "bg-[color:var(--color-accent)] text-[color:var(--color-accent-contrast)] shadow"
             }`}
           >
             {isGenerating ? "Generating…" : prompt.trim() ? "Generate environment" : "Generate random"}
@@ -667,20 +667,20 @@ export default function StudioPage() {
         </div>
       </div>
 
-      <div className="rounded-2xl border border-black/10 bg-black/5 p-5 dark:border-white/15 dark:bg-white/5">
+      <div className="rounded-2xl border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)] p-5">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
             <h3 className="text-lg font-semibold">Environment library</h3>
-            <p className="text-xs text-foreground/60">Review generated scenes, defaults, and source uploads.</p>
+            <p className="text-xs text-[color:var(--color-text-secondary)]">Review generated scenes, defaults, and source uploads.</p>
           </div>
-          <div className="inline-flex gap-2 rounded-full bg-background/40 p-1">
+          <div className="inline-flex gap-2 rounded-full bg-[color:var(--color-surface)]/40 p-1">
             {ENV_TABS.filter((tab) => isAdmin || tab !== "sources").map((tab) => (
               <button
                 key={tab}
                 type="button"
                 onClick={() => setEnvLibraryView(tab)}
                 className={`h-9 rounded-full px-3 text-xs font-semibold transition ${
-                  envLibraryView === tab ? "bg-foreground text-background" : "text-foreground/60"
+                  envLibraryView === tab ? "bg-[color:var(--color-accent)] text-[color:var(--color-accent-contrast)]" : "text-[color:var(--color-text-secondary)]"
                 }`}
               >
                 {tab === "generated" ? "Generated" : tab === "defaults" ? "Defaults" : "Sources"}
@@ -704,22 +704,22 @@ export default function StudioPage() {
           {items.map(({ gender, label, data }) => (
             <div
               key={gender}
-              className={`rounded-2xl overflow-hidden border bg-background shadow-sm transition ${
-                data ? "border-foreground/30 ring-2 ring-foreground/40" : "border-foreground/15"
+              className={`rounded-2xl overflow-hidden border bg-[color:var(--color-surface)] shadow-sm transition ${
+                data ? "border-[color:var(--color-border-strong)] ring-2 ring-[color:var(--color-accent)]" : "border-[color:var(--color-border)]"
               }`}
             >
-              <div className="relative aspect-[4/5] bg-black/5">
+              <div className="relative aspect-[4/5] bg-[color:var(--color-surface-strong)]">
                 {data?.url ? (
                   <>
                     <img src={data.url} alt={label} className="h-full w-full object-cover" />
-                    <div className="absolute left-3 top-3 inline-flex h-8 w-8 items-center justify-center rounded-full bg-blue-600/90 text-white">
+                    <div className="absolute left-3 top-3 inline-flex h-8 w-8 items-center justify-center rounded-full bg-[color:var(--color-accent)] text-[color:var(--color-foreground)]">
                       <CheckCircle2 className="size-4" aria-hidden="true" />
                       <span className="sr-only">Default model</span>
                     </div>
                     <div className="absolute right-3 top-3 flex flex-col gap-2 text-xs">
                       <button
                         type="button"
-                        className="inline-flex items-center gap-2 rounded-full bg-black/60 px-4 py-2 font-semibold text-white shadow hover:bg-black/70"
+                        className="inline-flex items-center gap-2 rounded-full bg-[color:var(--color-surface-strong)] px-4 py-2 font-semibold text-[color:var(--color-foreground)] shadow hover:bg-[color:var(--color-surface)]"
                         onClick={async () => {
                           if (!confirm("Remove this default?")) return;
                           try {
@@ -738,10 +738,10 @@ export default function StudioPage() {
                     </div>
                   </>
                 ) : (
-                  <div className="flex h-full items-center justify-center text-xs text-foreground/60">No default set</div>
+                  <div className="flex h-full items-center justify-center text-xs text-[color:var(--color-text-secondary)]">No default set</div>
                 )}
               </div>
-              <div className="px-3 py-3 text-xs text-foreground/70">
+              <div className="px-3 py-3 text-xs text-[color:var(--color-text-secondary)]">
                 <p className="text-sm font-semibold text-foreground">{label}</p>
                 <p className="truncate">{data?.name || (data ? "Untitled" : "—")}</p>
               </div>
@@ -759,28 +759,28 @@ export default function StudioPage() {
       return (
         <div className="grid gap-6 lg:grid-cols-2">
           {items.map((item) => (
-            <div key={item.gender} className={`rounded-2xl border border-black/10 bg-background p-5 dark:border-white/15 dark:bg-white/5 ${modelGender === item.gender ? "ring-2 ring-foreground" : "opacity-70"}`}>
+            <div key={item.gender} className={`rounded-2xl border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-5 ${modelGender === item.gender ? "ring-2 ring-[color:var(--color-accent)]" : "opacity-70"}`}>
               <div className="flex items-center justify-between">
                 <div>
                   <h4 className="text-sm font-semibold">{item.label}</h4>
-                  <p className="text-xs text-foreground/60">{item.persisted ? "Current reference" : "No source uploaded"}</p>
+                  <p className="text-xs text-[color:var(--color-text-secondary)]">{item.persisted ? "Current reference" : "No source uploaded"}</p>
                 </div>
-                {isModelSourceUploading && <span className="text-[11px] text-foreground/60">Uploading…</span>}
+                {isModelSourceUploading && <span className="text-[11px] text-[color:var(--color-text-secondary)]">Uploading…</span>}
               </div>
-              <div className="mt-3 aspect-[4/5] overflow-hidden rounded-xl border border-black/10 bg-black/5 dark:border-white/15">
+              <div className="mt-3 aspect-[4/5] overflow-hidden rounded-xl border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)]">
                 {(item.preview || item.persisted?.url) ? (
                   <img src={item.preview || item.persisted?.url} alt={item.label} className="h-full w-full object-cover" />
                 ) : (
-                  <div className="flex h-full items-center justify-center text-xs text-foreground/60">None</div>
+                  <div className="flex h-full items-center justify-center text-xs text-[color:var(--color-text-secondary)]">None</div>
                 )}
               </div>
               {isAdmin ? (
-                <label className="mt-3 inline-flex h-9 w-full cursor-pointer items-center justify-center rounded-md bg-foreground text-sm font-semibold text-background">
+                <label className="mt-3 inline-flex h-9 w-full cursor-pointer items-center justify-center rounded-md bg-[color:var(--color-accent)] text-sm font-semibold text-[color:var(--color-accent-contrast)]">
                   <input type="file" accept="image/*" className="hidden" onChange={item.picker} />
                   Replace source
                 </label>
               ) : (
-                <p className="mt-3 text-[11px] text-foreground/60">Contact an admin to update this source image.</p>
+                <p className="mt-3 text-[11px] text-[color:var(--color-text-secondary)]">Contact an admin to update this source image.</p>
               )}
             </div>
           ))}
@@ -794,12 +794,12 @@ export default function StudioPage() {
     });
 
     if (filtered.length === 0) {
-      return <p className="text-xs text-foreground/60">No generated models yet.</p>;
+      return <p className="text-xs text-[color:var(--color-text-secondary)]">No generated models yet.</p>;
     }
 
     return (
       <div className="space-y-3">
-        <div className="flex flex-wrap items-center gap-2 text-xs text-foreground/60">
+        <div className="flex flex-wrap items-center gap-2 text-xs text-[color:var(--color-text-secondary)]">
           <span>Filter by gender:</span>
           {GENDER_FILTERS.map((filter) => (
             <button
@@ -807,7 +807,7 @@ export default function StudioPage() {
               type="button"
               onClick={() => setModelGalleryFilter(filter)}
               className={`h-8 rounded-full border px-3 font-semibold ${
-                modelGalleryFilter === filter ? "border-foreground" : "border-foreground/30"
+                modelGalleryFilter === filter ? "border-foreground" : "border-[color:var(--color-border-strong)]"
               }`}
             >
               {filter === "all" ? "All" : filter === "man" ? "Men" : "Women"}
@@ -822,16 +822,16 @@ export default function StudioPage() {
             return (
               <div
                 key={item.s3_key}
-                className={`group rounded-2xl border bg-background overflow-hidden transition ${
+                className={`group rounded-2xl border bg-[color:var(--color-surface)] overflow-hidden transition ${
                   isDefault
-                    ? "border-blue-500 ring-2 ring-blue-300 shadow-lg"
-                    : "border-foreground/15 hover:border-foreground/40"
+                    ? "border-[color:var(--color-accent)] ring-2 ring-[color:var(--color-accent)] shadow-lg"
+                    : "border-[color:var(--color-border)] hover:border-[color:var(--color-border-strong)]"
                 }`}
               >
-                <div className="relative aspect-[3/4] md:aspect-[4/5] bg-black/5">
+                <div className="relative aspect-[3/4] md:aspect-[4/5] bg-[color:var(--color-surface-strong)]">
                   <img src={src} alt="Generated model" className="h-full w-full object-cover" />
                   {isDefault && (
-                    <div className="absolute left-3 top-3 inline-flex h-8 w-8 items-center justify-center rounded-full bg-blue-600/90 text-white">
+                    <div className="absolute left-3 top-3 inline-flex h-8 w-8 items-center justify-center rounded-full bg-[color:var(--color-accent)] text-[color:var(--color-foreground)]">
                       <CheckCircle2 className="size-4" aria-hidden="true" />
                       <span className="sr-only">Default model</span>
                     </div>
@@ -840,7 +840,7 @@ export default function StudioPage() {
                     {isDefault ? (
                       <button
                         type="button"
-                        className="inline-flex items-center gap-2 rounded-full bg-black/60 px-4 py-2 font-semibold text-white shadow hover:bg-black/70"
+                        className="inline-flex items-center gap-2 rounded-full bg-[color:var(--color-surface-strong)] px-4 py-2 font-semibold text-[color:var(--color-foreground)] shadow hover:bg-[color:var(--color-surface)]"
                         onClick={async () => {
                           if (!confirm("Remove this default?")) return;
                           try {
@@ -859,7 +859,7 @@ export default function StudioPage() {
                     ) : (
                       <button
                         type="button"
-                        className="inline-flex items-center gap-2 rounded-full bg-blue-600 px-4 py-2 font-semibold text-white shadow hover:bg-blue-700"
+                        className="inline-flex items-center gap-2 rounded-full bg-[color:var(--color-accent)] px-4 py-2 font-semibold text-[color:var(--color-foreground)] shadow hover:bg-[color:var(--color-accent)]/90"
                         onClick={async () => {
                           try {
                             const baseUrl = getApiBase();
@@ -881,7 +881,7 @@ export default function StudioPage() {
                     )}
                     <button
                       type="button"
-                      className="inline-flex items-center gap-2 rounded-full bg-red-600 px-4 py-2 font-semibold text-white shadow hover:bg-red-700"
+                      className="inline-flex items-center gap-2 rounded-full bg-red-600 px-4 py-2 font-semibold text-[color:var(--color-foreground)] shadow hover:bg-red-700"
                       onClick={async () => {
                         if (!confirm("Delete this model?")) return;
                         try {
@@ -912,13 +912,13 @@ export default function StudioPage() {
 
     return (
       <div className="space-y-6">
-        <div className="rounded-2xl border border-black/10 bg-black/5 p-5 dark:border-white/15 dark:bg-white/5">
+        <div className="rounded-2xl border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)] p-5">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div>
               <h3 className="text-lg font-semibold">Generate model</h3>
-              <p className="text-xs text-foreground/60">Provide an optional prompt to guide the outfit or style.</p>
+              <p className="text-xs text-[color:var(--color-text-secondary)]">Provide an optional prompt to guide the outfit or style.</p>
             </div>
-            <div className="inline-flex overflow-hidden rounded-lg border border-black/10 dark:border-white/15">
+            <div className="inline-flex overflow-hidden rounded-lg border border-[color:var(--color-border)]">
               {[
                 { key: "man", label: "Male" },
                 { key: "woman", label: "Female" },
@@ -928,7 +928,7 @@ export default function StudioPage() {
                   type="button"
                   onClick={() => setModelGender(item.key)}
                   className={`h-9 px-3 text-sm font-semibold ${
-                    modelGender === item.key ? "bg-foreground text-background" : "bg-transparent"
+                    modelGender === item.key ? "bg-[color:var(--color-accent)] text-[color:var(--color-accent-contrast)]" : "bg-transparent"
                   }`}
                 >
                   {item.label}
@@ -945,20 +945,20 @@ export default function StudioPage() {
               ].map((item) => (
                 <div
                   key={item.gender}
-                  className={`rounded-xl border border-black/10 bg-background p-3 dark:border-white/15 ${
-                    modelGender === item.gender ? "ring-2 ring-foreground" : "opacity-70"
+                  className={`rounded-xl border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-3 ${
+                    modelGender === item.gender ? "ring-2 ring-[color:var(--color-accent)]" : "opacity-70"
                   }`}
                 >
-                  <p className="text-xs font-semibold text-foreground/70">{item.label}</p>
-                  <div className="mt-2 aspect-[4/5] overflow-hidden rounded-lg border border-black/10 bg-black/5 dark:border-white/15">
+                  <p className="text-xs font-semibold text-[color:var(--color-text-secondary)]">{item.label}</p>
+                  <div className="mt-2 aspect-[4/5] overflow-hidden rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)]">
                     {(item.preview || item.persisted?.url) ? (
                       <img src={item.preview || item.persisted?.url} alt={item.label} className="h-full w-full object-cover" />
                     ) : (
-                      <div className="flex h-full items-center justify-center text-[11px] text-foreground/60">No source yet</div>
+                      <div className="flex h-full items-center justify-center text-[11px] text-[color:var(--color-text-secondary)]">No source yet</div>
                     )}
                   </div>
                   {modelGender === item.gender && (
-                    <label className="mt-3 inline-flex h-9 w-full cursor-pointer items-center justify-center rounded-md bg-foreground text-sm font-semibold text-background">
+                    <label className="mt-3 inline-flex h-9 w-full cursor-pointer items-center justify-center rounded-md bg-[color:var(--color-accent)] text-sm font-semibold text-[color:var(--color-accent-contrast)]">
                       <input type="file" accept="image/*" className="hidden" onChange={item.picker} />
                       Replace source
                     </label>
@@ -973,7 +973,7 @@ export default function StudioPage() {
             value={modelPrompt}
             onChange={(event) => setModelPrompt(event.target.value)}
             placeholder="e.g. natural daylight, smiling expression, casual denim outfit"
-            className="mt-4 w-full rounded-lg border border-black/10 bg-background/50 px-3 py-2 text-sm dark:border-white/15"
+            className="mt-4 w-full rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/50 px-3 py-2 text-sm"
           />
 
           <div className="mt-4 flex flex-col items-center gap-2 text-center">
@@ -983,30 +983,30 @@ export default function StudioPage() {
               disabled={!hasSource || isModelGenerating || isModelSourceUploading}
               className={`inline-flex h-12 w-full max-w-xs items-center justify-center rounded-xl px-6 text-base font-semibold ${
                 (!hasSource || isModelGenerating || isModelSourceUploading)
-                  ? "bg-foreground/30 text-background/60"
-                  : "bg-foreground text-background shadow"
+                  ? "bg-[color:var(--color-accent)]/60 text-[color:var(--color-accent-contrast)]/80"
+                  : "bg-[color:var(--color-accent)] text-[color:var(--color-accent-contrast)] shadow"
               }`}
             >
               {isModelGenerating ? "Generating…" : modelPrompt.trim() ? "Generate model" : "Generate random"}
             </button>
-            <span className="text-[11px] text-foreground/60">A source photo per gender is required before generating.</span>
+            <span className="text-[11px] text-[color:var(--color-text-secondary)]">A source photo per gender is required before generating.</span>
           </div>
         </div>
 
-        <div className="rounded-2xl border border-black/10 bg-black/5 p-5 dark:border-white/15 dark:bg-white/5">
+        <div className="rounded-2xl border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)] p-5">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div>
               <h3 className="text-lg font-semibold">Model library</h3>
-              <p className="text-xs text-foreground/60">Review generated variants, defaults, and source references.</p>
+              <p className="text-xs text-[color:var(--color-text-secondary)]">Review generated variants, defaults, and source references.</p>
             </div>
-            <div className="inline-flex gap-2 rounded-full bg-background/40 p-1">
+            <div className="inline-flex gap-2 rounded-full bg-[color:var(--color-surface)]/40 p-1">
               {MODEL_TABS.filter((tab) => tab !== "sources" || isAdmin).map((tab) => (
                 <button
                   key={tab}
                   type="button"
                   onClick={() => setModelLibraryView(tab)}
                   className={`h-9 rounded-full px-3 text-xs font-semibold transition ${
-                    modelLibraryView === tab ? "bg-foreground text-background" : "text-foreground/60"
+                    modelLibraryView === tab ? "bg-[color:var(--color-accent)] text-[color:var(--color-accent-contrast)]" : "text-[color:var(--color-text-secondary)]"
                   }`}
                 >
                   {tab === "generated" ? "Generated" : tab === "defaults" ? "Defaults" : "Sources"}
@@ -1022,25 +1022,25 @@ export default function StudioPage() {
 
   const renderPoseSection = () => (
     <div className="space-y-6">
-      <div className="rounded-2xl border border-black/10 bg-black/5 p-5 dark:border-white/15 dark:bg-white/5">
+      <div className="rounded-2xl border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)] p-5">
         <h3 className="text-lg font-semibold">Upload pose references</h3>
-        <p className="mt-1 text-xs text-foreground/60">Drop in up to 10 pose examples at a time to expand the catalog.</p>
+        <p className="mt-1 text-xs text-[color:var(--color-text-secondary)]">Drop in up to 10 pose examples at a time to expand the catalog.</p>
         <input
           type="file"
           accept="image/*"
           multiple
           onChange={handlePoseFilesChange}
-          className="mt-3 block w-full text-sm file:mr-3 file:rounded-md file:border file:border-black/10 file:bg-transparent file:px-3 file:py-2 dark:file:border-white/15"
+          className="mt-3 block w-full text-sm file:mr-3 file:rounded-md file:border file:border-[color:var(--color-border)] file:bg-transparent file:px-3 file:py-2"
         />
         {poseFiles.length > 0 && (
-          <div className="mt-3 flex items-center justify-between text-xs text-foreground/60">
+          <div className="mt-3 flex items-center justify-between text-xs text-[color:var(--color-text-secondary)]">
             <span>{poseFiles.length} file(s) selected</span>
             <button
               type="button"
               onClick={uploadPoseFiles}
               disabled={isPoseUploading}
               className={`inline-flex h-9 items-center justify-center rounded-md px-3 font-semibold ${
-                isPoseUploading ? "bg-foreground/30 text-background/60" : "bg-foreground text-background"
+                isPoseUploading ? "bg-[color:var(--color-accent)]/60 text-[color:var(--color-accent-contrast)]/80" : "bg-[color:var(--color-accent)] text-[color:var(--color-accent-contrast)]"
               }`}
             >
               {isPoseUploading ? "Uploading…" : "Upload"}
@@ -1049,17 +1049,17 @@ export default function StudioPage() {
         )}
       </div>
 
-      <div className="rounded-2xl border border-black/10 bg-black/5 p-5 dark:border-white/15 dark:bg-white/5">
+      <div className="rounded-2xl border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)] p-5">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
             <h3 className="text-lg font-semibold">Pose descriptions</h3>
-            <p className="text-xs text-foreground/60">Trigger description generation and manage existing entries.</p>
+            <p className="text-xs text-[color:var(--color-text-secondary)]">Trigger description generation and manage existing entries.</p>
           </div>
           <div className="flex items-center gap-2">
             <button
               type="button"
               onClick={refreshPoseDescriptions}
-              className="inline-flex h-9 items-center justify-center rounded-md border border-black/10 px-3 text-xs font-semibold dark:border-white/15"
+              className="inline-flex h-9 items-center justify-center rounded-md border border-[color:var(--color-border)] px-3 text-xs font-semibold"
             >
               Refresh
             </button>
@@ -1069,7 +1069,7 @@ export default function StudioPage() {
                 onClick={generatePoseDescriptions}
                 disabled={isPoseDescribing}
                 className={`inline-flex h-9 items-center justify-center rounded-md px-3 text-xs font-semibold ${
-                  isPoseDescribing ? "bg-foreground/30 text-background/60" : "bg-foreground text-background"
+                  isPoseDescribing ? "bg-[color:var(--color-accent)]/60 text-[color:var(--color-accent-contrast)]/80" : "bg-[color:var(--color-accent)] text-[color:var(--color-accent-contrast)]"
                 }`}
               >
                 {isPoseDescribing ? "Generating…" : "Generate from sources"}
@@ -1081,23 +1081,23 @@ export default function StudioPage() {
         <div className="mt-4 grid gap-3 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
           <div className="space-y-3">
             {poseDescs.length === 0 ? (
-              <p className="text-xs text-foreground/60">No descriptions yet.</p>
+              <p className="text-xs text-[color:var(--color-text-secondary)]">No descriptions yet.</p>
             ) : (
               <div className="grid gap-3 md:grid-cols-2">
                 {poseDescs.map((item) => (
-                  <div key={item.s3_key} className="rounded-xl border border-black/10 bg-background p-3 text-xs text-foreground/70 dark:border-white/15">
-                    <div className="truncate text-[10px] text-foreground/50">{item.s3_key}</div>
-                    <p className="mt-2 whitespace-pre-wrap text-foreground/80">{item.description || "No description"}</p>
+                  <div key={item.s3_key} className="rounded-xl border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-3 text-xs text-[color:var(--color-text-secondary)]">
+                    <div className="truncate text-[10px] text-[color:var(--color-text-tertiary)]">{item.s3_key}</div>
+                    <p className="mt-2 whitespace-pre-wrap text-[color:var(--color-foreground)]">{item.description || "No description"}</p>
                   </div>
                 ))}
               </div>
             )}
           </div>
-          <div className="rounded-xl border border-black/10 bg-background p-3 text-xs text-foreground/70 dark:border-white/15">
+          <div className="rounded-xl border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-3 text-xs text-[color:var(--color-text-secondary)]">
             <h4 className="text-sm font-semibold">Raw sources ({poseSources.length})</h4>
-            <p className="mt-1 text-[11px] text-foreground/60">Uploaded pose references awaiting descriptions.</p>
+            <p className="mt-1 text-[11px] text-[color:var(--color-text-secondary)]">Uploaded pose references awaiting descriptions.</p>
             {poseSources.length === 0 ? (
-              <p className="mt-3 text-[11px] text-foreground/60">No sources uploaded.</p>
+              <p className="mt-3 text-[11px] text-[color:var(--color-text-secondary)]">No sources uploaded.</p>
             ) : (
               <ul className="mt-3 space-y-1">
                 {poseSources.map((key) => (
@@ -1116,12 +1116,12 @@ export default function StudioPage() {
       <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">{currentCopy.title}</h1>
-          <p className="text-sm text-foreground/70">{currentCopy.description}</p>
+          <p className="text-sm text-[color:var(--color-text-secondary)]">{currentCopy.description}</p>
         </div>
         {isAdmin && (
           <a
             href="/studio/admin"
-            className="inline-flex h-9 items-center justify-center rounded-lg border border-foreground/20 px-3 text-xs font-semibold text-foreground/70 hover:border-foreground/40"
+            className="inline-flex h-9 items-center justify-center rounded-lg border border-[color:var(--color-border)] px-3 text-xs font-semibold text-[color:var(--color-text-secondary)] hover:border-[color:var(--color-border-strong)]"
           >
             Admin tools
           </a>
@@ -1139,13 +1139,13 @@ export default function StudioPage() {
               onClick={() => setActiveSection(item.key)}
               className={`inline-flex items-center gap-2 rounded-full px-5 py-2 text-sm font-semibold transition shadow-sm ${
                 isActive
-                  ? "bg-foreground text-background shadow-lg"
-                  : "border border-foreground/20 bg-background text-foreground/70 hover:border-foreground/40"
+                  ? "bg-[color:var(--color-accent)] text-[color:var(--color-accent-contrast)] shadow-lg"
+                  : "border border-[color:var(--color-border)] bg-[color:var(--color-surface)] text-[color:var(--color-text-secondary)] hover:border-[color:var(--color-border-strong)]"
               }`}
             >
               <span>{item.label}</span>
               {count > 0 && (
-                <span className={`rounded-full px-2 text-[11px] font-medium ${isActive ? "bg-background/30" : "bg-foreground/10 text-foreground"}`}>
+                <span className={`rounded-full px-2 text-[11px] font-medium ${isActive ? "bg-[color:var(--color-surface)]/30" : "bg-[color:var(--color-surface-strong)] text-[color:var(--color-text-secondary)]"}`}>
                   {count}
                 </span>
               )}


### PR DESCRIPTION
## Summary
- define shared surface, border, and accent CSS variables and update theme helpers to consume them
- restyle generator components, listings, and settings flows to use the new surface tokens and Calypso accent states
- refresh studio surfaces and admin tools to drop hard-coded grays in favor of the new palette

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cddb89fc1c833388ab4764eeb957fa