### PR TITLE
Align usage tracking with shared plan metadata and admin overrides

### DIFF
--- a/app/api/billing/checkout/route.js
+++ b/app/api/billing/checkout/route.js
@@ -1,0 +1,52 @@
+import { auth } from "@/app/lib/auth";
+import { getSessionBasics } from "@/app/lib/session";
+import { getApiBase, withUserId } from "@/app/lib/api";
+
+async function readJson(request) {
+  try {
+    return await request.json();
+  } catch {
+    return {};
+  }
+}
+
+async function forwardToBackend({ identity, body }) {
+  const baseUrl = getApiBase();
+  const headers = withUserId(
+    { "content-type": "application/json" },
+    identity
+  );
+  try {
+    const res = await fetch(`${baseUrl}/billing/checkout`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body ?? {}),
+      cache: "no-store",
+    });
+    const text = await res.text();
+    const responseHeaders = new Headers();
+    const contentType = res.headers.get("content-type") || "application/json";
+    responseHeaders.set("content-type", contentType);
+    return new Response(text, { status: res.status, headers: responseHeaders });
+  } catch (error) {
+    return new Response(JSON.stringify({ error: "checkout upstream unavailable" }), {
+      status: 502,
+      headers: { "content-type": "application/json" },
+    });
+  }
+}
+
+export async function POST(request) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  const { userId, email, isAdmin } = getSessionBasics(session);
+  if (!userId) {
+    return new Response(JSON.stringify({ error: "unauthorized" }), {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  const body = await readJson(request);
+  return forwardToBackend({ identity: { userId, email, isAdmin }, body });
+}
+

--- a/app/api/billing/portal/route.js
+++ b/app/api/billing/portal/route.js
@@ -1,0 +1,52 @@
+import { auth } from "@/app/lib/auth";
+import { getSessionBasics } from "@/app/lib/session";
+import { getApiBase, withUserId } from "@/app/lib/api";
+
+async function readJson(request) {
+  try {
+    return await request.json();
+  } catch {
+    return {};
+  }
+}
+
+async function forwardToBackend({ identity, body }) {
+  const baseUrl = getApiBase();
+  const headers = withUserId(
+    { "content-type": "application/json" },
+    identity
+  );
+  try {
+    const res = await fetch(`${baseUrl}/billing/portal`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body ?? {}),
+      cache: "no-store",
+    });
+    const text = await res.text();
+    const responseHeaders = new Headers();
+    const contentType = res.headers.get("content-type") || "application/json";
+    responseHeaders.set("content-type", contentType);
+    return new Response(text, { status: res.status, headers: responseHeaders });
+  } catch (error) {
+    return new Response(JSON.stringify({ error: "portal upstream unavailable" }), {
+      status: 502,
+      headers: { "content-type": "application/json" },
+    });
+  }
+}
+
+export async function POST(request) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  const { userId, email, isAdmin } = getSessionBasics(session);
+  if (!userId) {
+    return new Response(JSON.stringify({ error: "unauthorized" }), {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  const body = await readJson(request);
+  return forwardToBackend({ identity: { userId, email, isAdmin }, body });
+}
+

--- a/app/api/billing/usage/route.js
+++ b/app/api/billing/usage/route.js
@@ -1,0 +1,38 @@
+import { auth } from "@/app/lib/auth";
+import { getSessionBasics } from "@/app/lib/session";
+import { getApiBase, withUserId } from "@/app/lib/api";
+
+async function forwardToBackend(identity) {
+  const baseUrl = getApiBase();
+  const headers = withUserId({}, identity);
+  try {
+    const res = await fetch(`${baseUrl}/billing/usage`, {
+      method: "GET",
+      headers,
+      cache: "no-store",
+    });
+    const text = await res.text();
+    const responseHeaders = new Headers();
+    const contentType = res.headers.get("content-type") || "application/json";
+    responseHeaders.set("content-type", contentType);
+    return new Response(text, { status: res.status, headers: responseHeaders });
+  } catch (error) {
+    return new Response(JSON.stringify({ error: "usage upstream unavailable" }), {
+      status: 502,
+      headers: { "content-type": "application/json" },
+    });
+  }
+}
+
+export async function GET(request) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  const { userId, email, isAdmin } = getSessionBasics(session);
+  if (!userId) {
+    return new Response(JSON.stringify({ error: "unauthorized" }), {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    });
+  }
+  return forwardToBackend({ userId, email, isAdmin });
+}
+

--- a/app/billing/page.js
+++ b/app/billing/page.js
@@ -1,0 +1,215 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { toast } from "react-hot-toast";
+
+import { useSubscription } from "@/app/components/subscription-provider";
+import { getUsageOperations } from "@/app/lib/usage-costs";
+
+function formatDate(value) {
+  if (!value) return "—";
+  try {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return "—";
+    return date.toLocaleDateString();
+  } catch {
+    return "—";
+  }
+}
+
+export default function BillingPage() {
+  const {
+    usage,
+    plan,
+    allowance,
+    used,
+    remaining,
+    plans,
+    isBillingEnabled,
+    startCheckout,
+    openPortal,
+    manageUrl,
+    isUnlimited,
+    operationCosts,
+    usagePrecision,
+  } = useSubscription();
+  const [workingPlan, setWorkingPlan] = useState(null);
+  const [portalBusy, setPortalBusy] = useState(false);
+
+  const planId = plan?.id || null;
+  const planName = plan?.name || "Free";
+  const allowanceNumber = typeof allowance === "number" ? allowance : null;
+  const usedNumber = typeof used === "number" ? used : null;
+  const remainingNumber = typeof remaining === "number" ? Math.max(remaining, 0) : null;
+
+  const allowanceLabel = useMemo(() => {
+    if (allowanceNumber === null) return "—";
+    if (isUnlimited) return "Unlimited";
+    return `${allowanceNumber.toLocaleString()} / month`;
+  }, [allowanceNumber, isUnlimited]);
+
+  const remainingLabel = useMemo(() => {
+    if (isUnlimited) return "Unlimited";
+    if (remainingNumber === null) return "—";
+    return `${remainingNumber.toLocaleString()} left`;
+  }, [isUnlimited, remainingNumber]);
+
+  const operationDetails = useMemo(() => {
+    return getUsageOperations().map((operation) => ({
+      ...operation,
+      cost: operationCosts[operation.key] ?? operation.cost,
+    }));
+  }, [operationCosts]);
+
+  async function handleSelectPlan(option) {
+    if (!option?.id) {
+      toast.error("This plan is not configured. Set NEXT_PUBLIC_POLAR_PLAN_*_ID in your env file.");
+      return;
+    }
+    setWorkingPlan(option.key);
+    try {
+      const origin = typeof window !== "undefined" ? window.location.origin : undefined;
+      const successUrl = origin ? `${origin}/billing?status=success` : undefined;
+      const cancelUrl = origin ? `${origin}/billing?status=cancelled` : undefined;
+      await startCheckout(option.id, { successUrl, cancelUrl });
+      toast.success("Checkout opened. Complete the upgrade in the overlay or new tab.");
+    } catch (error) {
+      toast.error(error?.message || "Unable to start checkout.");
+    } finally {
+      setWorkingPlan(null);
+    }
+  }
+
+  async function handlePortal() {
+    setPortalBusy(true);
+    try {
+      const returnUrl = typeof window !== "undefined" ? window.location.href : undefined;
+      const url = await openPortal(returnUrl);
+      if (!url && manageUrl) {
+        try {
+          window.open(manageUrl, "_blank", "noopener,noreferrer");
+          toast.success("Customer portal opened in a new tab.");
+        } catch {
+          toast("Opening existing customer portal…");
+        }
+      } else if (!url) {
+        toast.error("No billing portal available yet.");
+      } else {
+        toast.success("Customer portal opened in a new tab.");
+      }
+    } catch (error) {
+      toast.error(error?.message || "Unable to open portal.");
+    } finally {
+      setPortalBusy(false);
+    }
+  }
+
+  const periodStart = usage?.period?.start;
+  const periodEnd = usage?.period?.end;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <header className="flex flex-col gap-2">
+        <h1 className="text-2xl font-semibold tracking-tight">Billing & usage</h1>
+        <p className="text-sm text-foreground/70">
+          Track your current allowance and upgrade to unlock more AI generations.
+        </p>
+      </header>
+
+      {!isBillingEnabled ? (
+        <div className="rounded-2xl border border-amber-500/50 bg-amber-500/10 p-4 text-sm text-amber-900 dark:border-amber-200/40 dark:bg-amber-200/10 dark:text-amber-100">
+          Billing isn&apos;t configured for this environment. Ask your administrator to add Polar credentials to the backend service.
+        </div>
+      ) : null}
+
+      <section className="rounded-3xl border border-[var(--color-border)] bg-[var(--color-surface)] p-6 shadow-lg sm:p-8">
+        <h2 className="text-lg font-semibold">Current period</h2>
+        <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="rounded-2xl border border-[var(--color-border)]/60 bg-[var(--color-background)]/40 p-4">
+            <p className="text-xs uppercase tracking-wide text-foreground/50">Plan</p>
+            <p className="mt-1 text-base font-semibold text-foreground">{planName}</p>
+            {plan?.interval ? (
+              <p className="text-xs text-foreground/60">{plan.interval}</p>
+            ) : null}
+          </div>
+          <div className="rounded-2xl border border-[var(--color-border)]/60 bg-[var(--color-background)]/40 p-4">
+            <p className="text-xs uppercase tracking-wide text-foreground/50">Allowance</p>
+            <p className="mt-1 text-base font-semibold text-foreground">{allowanceLabel}</p>
+          </div>
+          <div className="rounded-2xl border border-[var(--color-border)]/60 bg-[var(--color-background)]/40 p-4">
+            <p className="text-xs uppercase tracking-wide text-foreground/50">Used</p>
+            <p className="mt-1 text-base font-semibold text-foreground">
+              {usedNumber === null ? "—" : usedNumber.toLocaleString()}
+            </p>
+          </div>
+          <div className="rounded-2xl border border-[var(--color-border)]/60 bg-[var(--color-background)]/40 p-4">
+            <p className="text-xs uppercase tracking-wide text-foreground/50">Remaining</p>
+            <p className="mt-1 text-base font-semibold text-foreground">{remainingLabel}</p>
+          </div>
+        </div>
+        <div className="mt-4 flex flex-wrap items-center gap-4 text-xs text-foreground/60">
+          <span>Period: {formatDate(periodStart)} → {formatDate(periodEnd)}</span>
+          {planId ? (
+            <button
+              type="button"
+              onClick={handlePortal}
+              disabled={portalBusy}
+              className="inline-flex items-center justify-center rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-strong)] px-3 py-2 text-xs font-semibold text-foreground transition hover:bg-[var(--color-accent-soft)] disabled:opacity-60"
+            >
+              {portalBusy ? "Opening portal…" : "Manage subscription"}
+            </button>
+          ) : null}
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-lg font-semibold">Choose a plan</h2>
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {plans.map((option) => {
+            const isCurrent = planId && option.id === planId;
+            const busy = workingPlan === option.key;
+            const disabled = !option.isAvailable || busy || !isBillingEnabled;
+            const quota =
+              option.allowance === 0
+                ? "Unlimited generations"
+                : `${option.allowance.toLocaleString()} generations / month`;
+            return (
+              <div
+                key={option.key}
+                className={
+                  "flex h-full flex-col justify-between rounded-3xl border border-[var(--color-border)] bg-[var(--color-surface)] p-6 shadow-lg"
+                }
+              >
+                <div className="flex flex-col gap-3">
+                  <div>
+                    <p className="text-xs uppercase tracking-wide text-foreground/50">{option.tagline}</p>
+                    <h3 className="mt-1 text-xl font-semibold text-foreground">{option.name}</h3>
+                    <p className="text-sm text-foreground/70">{option.price}</p>
+                  </div>
+                  <p className="text-sm font-medium text-foreground">{quota}</p>
+                  <ul className="space-y-2 text-xs text-foreground/70">
+                    {option.features.map((feature) => (
+                      <li key={feature} className="flex items-start gap-2">
+                        <span className="mt-1 inline-block size-1.5 rounded-full bg-[var(--color-accent)]" />
+                        <span>{feature}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+                <button
+                  type="button"
+                  disabled={disabled}
+                  onClick={() => handleSelectPlan(option)}
+                  className="mt-6 inline-flex items-center justify-center rounded-lg border border-[var(--color-border)] bg-[var(--color-background)] px-4 py-2 text-sm font-semibold text-foreground transition hover:bg-[var(--color-accent-soft)] disabled:opacity-60"
+                >
+                  {isCurrent ? "Current plan" : busy ? "Opening checkout…" : option.isAvailable ? "Select plan" : "Configure plan"}
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+    </div>
+  );
+}
+

--- a/app/components/pose-status-list.js
+++ b/app/components/pose-status-list.js
@@ -7,6 +7,7 @@ export function PoseStatusList({ items }) {
     if (status === "running") return "Generating…";
     if (status === "done") return "Ready";
     if (status === "error") return error || "Failed";
+    if (status === "blocked") return "Upgrade required";
     return "Queued";
   };
 
@@ -23,7 +24,9 @@ export function PoseStatusList({ items }) {
                   ? "text-red-500"
                   : status === "done"
                     ? "text-green-400"
-                    : "text-foreground/60"
+                    : status === "blocked"
+                      ? "text-amber-400"
+                      : "text-foreground/60"
               }
             >
               {resolveStatusLabel(status, error)}

--- a/app/components/subscription-provider.js
+++ b/app/components/subscription-provider.js
@@ -1,0 +1,282 @@
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { createAuthClient } from "better-auth/react";
+
+import { getSessionBasics } from "@/app/lib/session";
+import { getSubscriptionPlans } from "@/app/lib/subscription-config";
+import { getUsageCosts, USAGE_PRECISION as DEFAULT_USAGE_PRECISION } from "@/app/lib/usage-costs";
+
+const authClient = createAuthClient();
+const SubscriptionContext = createContext(undefined);
+const PLAN_OPTIONS = getSubscriptionPlans();
+const DEFAULT_OPERATION_COSTS = getUsageCosts();
+
+function extractUsage(payload) {
+  if (!payload || typeof payload !== "object") return null;
+  if (payload.usage && typeof payload.usage === "object") return payload.usage;
+  if (
+    typeof payload.allowance === "number" &&
+    typeof payload.remaining === "number" &&
+    typeof payload.used === "number"
+  ) {
+    return payload;
+  }
+  return null;
+}
+
+async function readResponseBody(res) {
+  const text = await res.text();
+  if (!text) return {};
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { error: text };
+  }
+}
+
+function resolveCheckoutUrl(checkout) {
+  if (!checkout || typeof checkout !== "object") return null;
+  return (
+    checkout.url ||
+    checkout.checkout_url ||
+    checkout.checkout?.url ||
+    checkout.link_url ||
+    null
+  );
+}
+
+function resolvePortalUrl(portal) {
+  if (!portal || typeof portal !== "object") return null;
+  if (typeof portal.url === "string" && portal.url) return portal.url;
+  if (portal.session && typeof portal.session === "object" && portal.session.url) {
+    return portal.session.url;
+  }
+  return null;
+}
+
+async function launchEmbeddedCheckout(url, refreshUsage, themeOverride) {
+  if (typeof window === "undefined" || !url) return false;
+  try {
+    const { PolarEmbedCheckout } = await import("@polar-sh/checkout/embed");
+    const theme =
+      themeOverride ||
+      (document.documentElement.classList.contains("dark") ? "dark" : "light");
+    const instance = await PolarEmbedCheckout.create(url, theme);
+    instance.addEventListener("success", async () => {
+      if (typeof refreshUsage === "function") await refreshUsage();
+    });
+    instance.addEventListener("close", () => {
+      try {
+        instance.close();
+      } catch {}
+    });
+    return true;
+  } catch (error) {
+    try {
+      window.open(url, "_blank", "noopener,noreferrer");
+    } catch {}
+    return false;
+  }
+}
+
+export function SubscriptionProvider({ children }) {
+  const { data: session } = authClient.useSession();
+  const { userId } = getSessionBasics(session);
+
+  const [usage, setUsage] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [billingEnabled, setBillingEnabled] = useState(true);
+  const [manageUrl, setManageUrl] = useState(null);
+  const fetchAbortRef = useRef(0);
+
+  const applyUsageFromResponse = useCallback((payload) => {
+    const next = extractUsage(payload);
+    if (next) {
+      setUsage(next);
+      return next;
+    }
+    return null;
+  }, []);
+
+  const refresh = useCallback(async () => {
+    if (!userId) {
+      setUsage(null);
+      setBillingEnabled(true);
+      setManageUrl(null);
+      return;
+    }
+    const runId = Date.now();
+    fetchAbortRef.current = runId;
+    setLoading(true);
+    try {
+      const res = await fetch("/api/billing/usage", {
+        method: "GET",
+        cache: "no-store",
+      });
+      const data = await readResponseBody(res);
+      if (fetchAbortRef.current !== runId) return;
+      if (res.status === 503) {
+        setBillingEnabled(false);
+      } else {
+        setBillingEnabled(true);
+      }
+      if (!res.ok) {
+        const message = data?.error || "Failed to load usage";
+        setError(new Error(message));
+        return;
+      }
+      setError(null);
+      applyUsageFromResponse(data);
+    } catch (err) {
+      if (fetchAbortRef.current !== runId) return;
+      setError(err instanceof Error ? err : new Error("Failed to load usage"));
+    } finally {
+      if (fetchAbortRef.current === runId) setLoading(false);
+    }
+  }, [applyUsageFromResponse, userId]);
+
+  useEffect(() => {
+    if (!userId) {
+      setUsage(null);
+      setManageUrl(null);
+      return;
+    }
+    refresh();
+  }, [userId, refresh]);
+
+  const startCheckout = useCallback(
+    async (planId, { successUrl, cancelUrl, theme } = {}) => {
+      if (!userId) throw new Error("Sign in to manage billing");
+      if (!planId) throw new Error("Plan unavailable");
+
+      const payload = {
+        plan_id: planId,
+        success_url: successUrl,
+        cancel_url: cancelUrl,
+      };
+      if (session?.user?.email) payload.customer_email = session.user.email;
+
+      const res = await fetch("/api/billing/checkout", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload),
+        cache: "no-store",
+      });
+      const data = await readResponseBody(res);
+      applyUsageFromResponse(data);
+      if (!res.ok) {
+        throw new Error(data?.error || "Unable to start checkout");
+      }
+
+      const checkout = data?.checkout || data;
+      const url = resolveCheckoutUrl(checkout);
+      const opened = await launchEmbeddedCheckout(url, refresh, theme);
+      if (!opened && url && typeof window !== "undefined") {
+        try {
+          window.open(url, "_blank", "noopener,noreferrer");
+        } catch {}
+      }
+      return { checkout, url, opened };
+    },
+    [applyUsageFromResponse, refresh, session?.user?.email, userId]
+  );
+
+  const openPortal = useCallback(
+    async (returnUrl) => {
+      if (!userId) throw new Error("Sign in to manage billing");
+      const res = await fetch("/api/billing/portal", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(returnUrl ? { return_url: returnUrl } : {}),
+        cache: "no-store",
+      });
+      const data = await readResponseBody(res);
+      applyUsageFromResponse(data);
+      if (!res.ok) {
+        throw new Error(data?.error || "Unable to open portal");
+      }
+      const url = resolvePortalUrl(data?.portal || data);
+      if (url) {
+        setManageUrl(url);
+        if (typeof window !== "undefined") {
+          try {
+            window.open(url, "_blank", "noopener,noreferrer");
+          } catch {}
+        }
+      }
+      return url;
+    },
+    [applyUsageFromResponse, userId]
+  );
+
+  const allowance = typeof usage?.allowance === "number" ? usage.allowance : null;
+  const used = typeof usage?.used === "number" ? usage.used : null;
+  const remaining = typeof usage?.remaining === "number" ? usage.remaining : null;
+  const plan = usage?.plan || null;
+  const isUnlimited = Boolean(usage?.is_unlimited);
+  const rawUsageCosts =
+    usage?.costs && typeof usage.costs === "object" ? usage.costs : undefined;
+  const operationCosts = useMemo(
+    () => ({
+      ...DEFAULT_OPERATION_COSTS,
+      ...(rawUsageCosts || {}),
+    }),
+    [rawUsageCosts]
+  );
+  const usagePrecision = Number.isFinite(usage?.precision)
+    ? Number(usage.precision)
+    : DEFAULT_USAGE_PRECISION;
+
+  const value = useMemo(
+    () => ({
+      isLoading: loading,
+      error,
+      usage,
+      plan,
+      allowance,
+      used,
+      remaining,
+      isBillingEnabled: billingEnabled,
+      manageUrl,
+      plans: PLAN_OPTIONS,
+      isUnlimited,
+      operationCosts,
+      usagePrecision,
+      refresh,
+      applyUsageFromResponse,
+      startCheckout,
+      openPortal,
+    }),
+    [
+      allowance,
+      applyUsageFromResponse,
+      billingEnabled,
+      error,
+      loading,
+      manageUrl,
+      operationCosts,
+      openPortal,
+      plan,
+      refresh,
+      remaining,
+      startCheckout,
+      usage,
+      used,
+      usagePrecision,
+      isUnlimited,
+    ]
+  );
+
+  return <SubscriptionContext.Provider value={value}>{children}</SubscriptionContext.Provider>;
+}
+
+export function useSubscription() {
+  const context = useContext(SubscriptionContext);
+  if (!context) {
+    throw new Error("useSubscription must be used within SubscriptionProvider");
+  }
+  return context;
+}
+

--- a/app/components/top-nav.js
+++ b/app/components/top-nav.js
@@ -3,42 +3,94 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import clsx from "clsx";
-import { Sparkles, Palette, Settings, List } from "lucide-react";
+import { Sparkles, Palette, Settings, List, CreditCard } from "lucide-react";
+
+import { useSubscription } from "./subscription-provider";
 
 const links = [
   { href: "/", label: "Create", icon: Sparkles },
   { href: "/studio", label: "Studio", icon: Palette },
   { href: "/listings", label: "Listings", icon: List },
+  { href: "/billing", label: "Billing", icon: CreditCard },
   { href: "/settings", label: "Settings", icon: Settings },
 ];
 
 export default function TopNav() {
   const pathname = usePathname();
+  const { plan, allowance, remaining, isBillingEnabled, isUnlimited } = useSubscription();
+
+  const planName = plan?.name || "Free";
+  const allowanceNumber = typeof allowance === "number" ? allowance : null;
+  const remainingNumber =
+    typeof remaining === "number" ? Math.max(remaining, 0) : null;
+  const quotaBadgeLabel = isUnlimited
+    ? "Unlimited"
+    : remainingNumber !== null
+      ? `${remainingNumber.toLocaleString()} left`
+      : "—";
+  const usageActive = pathname === "/billing" || pathname?.startsWith("/billing/");
+  const lowQuota =
+    !isUnlimited &&
+    allowanceNumber &&
+    remainingNumber !== null &&
+    remainingNumber <= Math.max(1, Math.round(allowanceNumber * 0.15));
+  const showQuotaBadge = isUnlimited || allowanceNumber !== null;
+
+  const badgeClass = lowQuota
+    ? "bg-amber-500/20 text-amber-100"
+    : "bg-[var(--color-accent-soft)] text-[var(--color-foreground)]";
 
   return (
     <nav className="pointer-events-none fixed bottom-4 left-0 right-0 z-40 flex justify-center">
-      <div className="pointer-events-auto flex items-center gap-1 rounded-2xl border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] px-2 py-2 shadow-[0_18px_60px_var(--color-border-strong)] backdrop-blur">
-        {links.map((link) => {
-          const Icon = link.icon;
-          const active = pathname === link.href || pathname?.startsWith(`${link.href}/`);
-          return (
-            <Link
-              key={link.href}
-              href={link.href}
-              aria-current={active ? "page" : undefined}
-              aria-label={active ? `${link.label} current page` : link.label}
-              className={clsx(
-                "flex h-12 min-w-[72px] flex-col items-center justify-center rounded-xl px-3 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-surface-strong)]",
-                active
-                  ? "bg-[var(--color-accent)] text-[var(--color-foreground)] shadow-[0_12px_35px_var(--color-border-strong)]"
-                  : "text-[var(--color-foreground)]/70 hover:bg-[var(--color-accent-soft)] hover:text-[var(--color-foreground)] focus-visible:bg-[var(--color-accent-soft)] focus-visible:text-[var(--color-foreground)]"
-              )}
-            >
-              <Icon className="mb-1 size-4" />
-              {link.label}
-            </Link>
-          );
-        })}
+      <div className="pointer-events-auto flex items-center gap-2 rounded-2xl border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] px-2 py-2 shadow-[0_18px_60px_var(--color-border-strong)] backdrop-blur">
+        <div className="flex items-center gap-1">
+          {links.map((link) => {
+            const Icon = link.icon;
+            const active = pathname === link.href || pathname?.startsWith(`${link.href}/`);
+            return (
+              <Link
+                key={link.href}
+                href={link.href}
+                aria-current={active ? "page" : undefined}
+                aria-label={active ? `${link.label} current page` : link.label}
+                className={clsx(
+                  "flex h-12 min-w-[72px] flex-col items-center justify-center rounded-xl px-3 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-surface-strong)]",
+                  active
+                    ? "bg-[var(--color-accent)] text-[var(--color-foreground)] shadow-[0_12px_35px_var(--color-border-strong)]"
+                    : "text-[var(--color-foreground)]/70 hover:bg-[var(--color-accent-soft)] hover:text-[var(--color-foreground)] focus-visible:bg-[var(--color-accent-soft)] focus-visible:text-[var(--color-foreground)]"
+                )}
+              >
+                <Icon className="mb-1 size-4" />
+                {link.label}
+              </Link>
+            );
+          })}
+        </div>
+        {isBillingEnabled ? (
+          <Link
+            href="/billing"
+            aria-label="Open billing overview"
+            className={clsx(
+              "flex h-12 items-center gap-2 rounded-xl border border-[var(--color-border-strong)]/40 px-3 text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-surface-strong)]",
+              usageActive
+                ? "bg-[var(--color-accent-soft)] text-[var(--color-foreground)]"
+                : "text-[var(--color-foreground)]/80 hover:bg-[var(--color-accent-soft)] hover:text-[var(--color-foreground)]"
+            )}
+          >
+            <div className="flex items-center justify-center rounded-full bg-[var(--color-border-strong)]/20 p-1">
+              <CreditCard className="size-4" />
+            </div>
+            <div className="flex flex-col leading-tight">
+              <span className="text-[10px] uppercase tracking-wide text-[var(--color-foreground)]/50">Plan</span>
+              <span className="text-sm font-semibold text-[var(--color-foreground)]">{planName}</span>
+            </div>
+            {showQuotaBadge ? (
+              <span className={clsx("ml-2 rounded-full px-2 py-0.5 text-[10px] font-semibold", badgeClass)}>
+                {quotaBadgeLabel}
+              </span>
+            ) : null}
+          </Link>
+        ) : null}
       </div>
     </nav>
   );

--- a/app/hooks/use-listing-generator.js
+++ b/app/hooks/use-listing-generator.js
@@ -1,10 +1,11 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { toast } from "react-hot-toast";
 
 import { getApiBase, withUserId } from "@/app/lib/api";
 import { broadcastListingsUpdated } from "@/app/lib/listings-events";
+import { useSubscription } from "@/app/components/subscription-provider";
 
 export function useListingGenerator({
   selectedFile,
@@ -22,6 +23,7 @@ export function useListingGenerator({
   desc,
   productCondition,
   userId,
+  user,
   flowMode,
   resolvePoseInstruction,
   computeEffectivePrompt,
@@ -29,20 +31,84 @@ export function useListingGenerator({
   const [isGenerating, setIsGenerating] = useState(false);
   const [poseStatus, setPoseStatus] = useState({});
   const [poseErrors, setPoseErrors] = useState({});
+  const { usage, isBillingEnabled, applyUsageFromResponse, isUnlimited, operationCosts } =
+    useSubscription();
+  const quotaToastRef = useRef(null);
+
+  const showQuotaToast = useCallback(() => {
+    if (quotaToastRef.current) return;
+    quotaToastRef.current = toast.custom(
+      (t) => (
+        <div className="flex items-center gap-3 rounded-xl border border-amber-500/60 bg-amber-500/10 px-4 py-3 text-sm text-amber-900 shadow-xl dark:border-amber-300/40 dark:bg-amber-300/10 dark:text-amber-100">
+          <span>Quota reached — visit Billing to upgrade.</span>
+          <button
+            type="button"
+            className="rounded-lg bg-amber-500/80 px-3 py-1 text-xs font-semibold text-amber-950 transition hover:bg-amber-500"
+            onClick={() => {
+              toast.dismiss(t.id);
+              quotaToastRef.current = null;
+              window.location.href = "/billing";
+            }}
+          >
+            View plans
+          </button>
+        </div>
+      ),
+      { duration: 6000 }
+    );
+    setTimeout(() => {
+      quotaToastRef.current = null;
+    }, 6500);
+  }, []);
 
   const handleGenerate = useCallback(async () => {
     if (!selectedFile) return;
+
+    const authIdentity = user || { userId };
+    const remainingQuota =
+      typeof usage?.remaining === "number" ? usage.remaining : null;
+    const listingCost = operationCosts["listing.create"] ?? 1;
+    if (
+      !isUnlimited &&
+      isBillingEnabled &&
+      remainingQuota !== null &&
+      remainingQuota < listingCost
+    ) {
+      showQuotaToast();
+      return;
+    }
+
+    const readJson = async (res) => {
+      const text = await res.text();
+      if (!text) return {};
+      try {
+        return JSON.parse(text);
+      } catch {
+        return { error: text };
+      }
+    };
+
+    const quotaError = (payload) => {
+      const error = new Error("quota exceeded");
+      error.code = "QUOTA_EXCEEDED";
+      error.payload = payload;
+      return error;
+    };
 
     try {
       setIsGenerating(true);
       const baseUrl = getApiBase();
 
       const imageCount = plannedImagesCount;
-      const poseSlots = Array.from({ length: imageCount }, (_, idx) => ({ key: `slot-${idx + 1}`, index: idx }));
+      const poseSlots = Array.from({ length: imageCount }, (_, idx) => ({
+        key: `slot-${idx + 1}`,
+        index: idx,
+      }));
 
-      const envDefaultKey = options.environment === "studio" && (selectedEnvDefaultKey || envDefaults[0]?.s3_key)
-        ? (selectedEnvDefaultKey || envDefaults[0]?.s3_key)
-        : undefined;
+      const envDefaultKey =
+        options.environment === "studio" && (selectedEnvDefaultKey || envDefaults[0]?.s3_key)
+          ? selectedEnvDefaultKey || envDefaults[0]?.s3_key
+          : undefined;
 
       const lform = new FormData();
       lform.append("image", selectedFile);
@@ -64,44 +130,35 @@ export function useListingGenerator({
       if (promptDirty) lform.append("prompt_override", promptInput.trim());
       if (garmentType) lform.append("garment_type_override", garmentType);
       if (title) lform.append("title", title);
+
       const toastId = toast.loading("Creating listing…");
-      const lres = await fetch(`${baseUrl}/listing`, { method: "POST", body: lform, headers: withUserId({}, userId) });
-      if (!lres.ok) throw new Error(await lres.text());
-      const listing = await lres.json();
-      const listingId = listing?.id;
+      const lres = await fetch(`${baseUrl}/listing`, {
+        method: "POST",
+        body: lform,
+        headers: withUserId({}, authIdentity),
+      });
+      const listingPayload = await readJson(lres);
+      if (listingPayload) applyUsageFromResponse(listingPayload);
+      if (!lres.ok) {
+        if (lres.status === 402) {
+          showQuotaToast();
+          toast.error("Quota exceeded. Upgrade to continue.", { id: toastId });
+          return;
+        }
+        throw new Error(
+          listingPayload?.error || listingPayload?.detail || "Failed to create listing"
+        );
+      }
+      const listingId = listingPayload?.id;
       if (!listingId) throw new Error("No listing id");
       broadcastListingsUpdated();
 
       let done = 0;
       toast.loading(`Generating images ${done}/${poseSlots.length}…`, { id: toastId });
       const initialStatus = {};
-      for (const slot of poseSlots) initialStatus[slot.key] = "running";
+      for (const slot of poseSlots) initialStatus[slot.key] = "queued";
       setPoseStatus(initialStatus);
       setPoseErrors({});
-
-      const limit = (n, fns) => new Promise((resolve) => {
-        const out = new Array(fns.length);
-        let i = 0;
-        let running = 0;
-        let finished = 0;
-        const next = () => {
-          if (finished >= fns.length) return resolve(out);
-          while (running < n && i < fns.length) {
-            const idx = i;
-            i += 1;
-            running += 1;
-            fns[idx]()
-              .then((v) => { out[idx] = { status: "fulfilled", value: v }; })
-              .catch((e) => { out[idx] = { status: "rejected", reason: e }; })
-              .finally(() => {
-                running -= 1;
-                finished += 1;
-                next();
-              });
-          }
-        };
-        next();
-      });
 
       const buildCommonForm = (slotIndex) => {
         const form = new FormData();
@@ -136,59 +193,93 @@ export function useListingGenerator({
         return computeEffectivePrompt(slotIndex, false);
       };
 
-      const runPose = ({ key, index: slotIndex }) => async () => {
+      const runPose = async ({ key, index: slotIndex }) => {
         const common = buildCommonForm(slotIndex);
         const prompt = buildPrompt(slotIndex);
         const classicReq = async () => {
           const f = cloneForm(common);
           f.append("prompt_override", prompt);
-          const res = await fetch(`${baseUrl}/edit/json`, { method: "POST", body: f, headers: withUserId({}, userId) });
-          if (!res.ok) throw new Error(await res.text());
-          return res.json();
+          const res = await fetch(`${baseUrl}/edit/json`, {
+            method: "POST",
+            body: f,
+            headers: withUserId({}, authIdentity),
+          });
+          const payload = await readJson(res);
+          if (payload) applyUsageFromResponse(payload);
+          if (!res.ok) {
+            if (res.status === 402) throw quotaError(payload);
+            throw new Error(payload?.error || payload?.detail || "Generation failed");
+          }
+          return payload;
         };
         const seqReq = async () => {
           const f = cloneForm(common);
-          const res = await fetch(`${baseUrl}/edit/sequential/json`, { method: "POST", body: f, headers: withUserId({}, userId) });
-          if (!res.ok) throw new Error(await res.text());
-          return res.json();
-        };
-        let classicP = null;
-        let seqP = null;
-        if (flowMode === "classic") classicP = classicReq();
-        else if (flowMode === "sequential") seqP = seqReq();
-        else {
-          classicP = classicReq();
-          seqP = seqReq();
-        }
-        let firstDone = false;
-        const markDone = () => {
-          if (!firstDone) {
-            firstDone = true;
-            done += 1;
-            toast.loading(`Generating images ${done}/${poseSlots.length}…`, { id: toastId });
-            setPoseStatus((s) => ({ ...s, [key]: "done" }));
+          const res = await fetch(`${baseUrl}/edit/sequential/json`, {
+            method: "POST",
+            body: f,
+            headers: withUserId({}, authIdentity),
+          });
+          const payload = await readJson(res);
+          if (payload) applyUsageFromResponse(payload);
+          if (!res.ok) {
+            if (res.status === 402) throw quotaError(payload);
+            throw new Error(payload?.error || payload?.detail || "Generation failed");
           }
+          return payload;
         };
-        if (classicP) classicP.then(() => markDone()).catch(() => {});
-        if (seqP) seqP.then(() => markDone()).catch(() => {});
-        const results = await Promise.all(
-          [classicP, seqP]
-            .filter(Boolean)
-            .map((p) => p.then((v) => ({ ok: true, v })).catch((e) => ({ ok: false, e })))
-        );
-        const ok = results.find((r) => r.ok);
-        if (ok) {
-          return ok.v;
+        const requests = [];
+        if (flowMode === "classic") requests.push(classicReq());
+        else if (flowMode === "sequential") requests.push(seqReq());
+        else {
+          requests.push(classicReq(), seqReq());
         }
-        setPoseStatus((s) => ({ ...s, [key]: "error" }));
-        setPoseErrors((e) => ({ ...e, [key]: results.map((r) => r.e?.message || "Failed").join("; ") }));
-        throw new Error(`Pose ${slotIndex + 1} failed`);
+        const results = await Promise.all(
+          requests.map((promise) =>
+            promise
+              .then((value) => ({ ok: true, value }))
+              .catch((error) => ({ ok: false, error }))
+          )
+        );
+        const ok = results.find((entry) => entry.ok);
+        if (ok) return ok.value;
+        const message = results
+          .map((entry) => entry.error?.message || "Failed")
+          .join("; ");
+        throw new Error(message || `Pose ${slotIndex + 1} failed`);
       };
 
-      const tasks = poseSlots.map((slot) => runPose(slot));
-      const settled = await limit(2, tasks);
-      const okAny = settled.some((r) => r && r.status === "fulfilled");
-      if (!okAny) throw new Error("All generations failed");
+      let quotaHit = false;
+      for (let idx = 0; idx < poseSlots.length; idx += 1) {
+        const slot = poseSlots[idx];
+        if (quotaHit) {
+          setPoseStatus((s) => ({ ...s, [slot.key]: "blocked" }));
+          continue;
+        }
+        setPoseStatus((s) => ({ ...s, [slot.key]: "running" }));
+        try {
+          await runPose(slot);
+          done += 1;
+          toast.loading(`Generating images ${done}/${poseSlots.length}…`, { id: toastId });
+          setPoseStatus((s) => ({ ...s, [slot.key]: "done" }));
+        } catch (error) {
+          if (error?.code === "QUOTA_EXCEEDED") {
+            quotaHit = true;
+            if (error.payload) applyUsageFromResponse(error.payload);
+            showQuotaToast();
+            setPoseStatus((s) => ({ ...s, [slot.key]: "blocked" }));
+            for (let next = idx + 1; next < poseSlots.length; next += 1) {
+              const nextSlot = poseSlots[next];
+              setPoseStatus((s) => ({ ...s, [nextSlot.key]: "blocked" }));
+            }
+            toast.error("Quota exceeded. Upgrade to continue.", { id: toastId });
+            break;
+          }
+          setPoseStatus((s) => ({ ...s, [slot.key]: "error" }));
+          setPoseErrors((prev) => ({ ...prev, [slot.key]: error?.message || "Failed" }));
+        }
+      }
+
+      if (quotaHit) return;
 
       if (descEnabled) {
         try {
@@ -201,7 +292,11 @@ export function useListingGenerator({
           if (productCondition) dform.append("condition", productCondition);
           dform.append("listing_id", listingId);
           toast.loading("Generating description…", { id: toastId });
-          await fetch(`${baseUrl}/describe`, { method: "POST", body: dform, headers: withUserId({}, userId) });
+          await fetch(`${baseUrl}/describe`, {
+            method: "POST",
+            body: dform,
+            headers: withUserId({}, authIdentity),
+          });
         } catch {}
       }
 
@@ -209,29 +304,36 @@ export function useListingGenerator({
       window.location.href = `/listing/${listingId}`;
     } catch (err) {
       console.error(err);
-      toast.error("Generation failed. Check backend/API key.");
+      toast.error(err?.message || "Generation failed. Check backend/API key.");
     } finally {
       setIsGenerating(false);
     }
   }, [
-    selectedFile,
-    plannedImagesCount,
-    options,
-    selectedEnvDefaultKey,
+    applyUsageFromResponse,
+    computeEffectivePrompt,
+    desc,
+    descEnabled,
     envDefaults,
+    flowMode,
+    garmentType,
+    isBillingEnabled,
     modelDefaults,
-    useModelImage,
+    options,
+    plannedImagesCount,
+    productCondition,
     promptDirty,
     promptInput,
-    garmentType,
-    title,
-    descEnabled,
-    desc,
-    productCondition,
-    userId,
-    flowMode,
     resolvePoseInstruction,
-    computeEffectivePrompt,
+    selectedEnvDefaultKey,
+    selectedFile,
+    showQuotaToast,
+    title,
+    operationCosts,
+    usage?.remaining,
+    isUnlimited,
+    useModelImage,
+    userId,
+    user,
   ]);
 
   return {

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,6 +1,7 @@
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import AppShell from "@/app/components/app-shell";
+import { SubscriptionProvider } from "@/app/components/subscription-provider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -21,7 +22,9 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <AppShell>{children}</AppShell>
+        <SubscriptionProvider>
+          <AppShell>{children}</AppShell>
+        </SubscriptionProvider>
       </body>
     </html>
   );

--- a/app/lib/admin.js
+++ b/app/lib/admin.js
@@ -17,8 +17,7 @@ export function isAdminEmail(email) {
   const emails = parseAllowedEmails();
   const domain = getAllowedDomain();
 
-  // If no allowlist configured, allow any signed-in user
-  if (emails.length === 0 && !domain) return true;
+  if (emails.length === 0 && !domain) return false;
 
   if (emails.includes(lower)) return true;
   if (domain) {

--- a/app/lib/api.js
+++ b/app/lib/api.js
@@ -2,9 +2,19 @@ export function getApiBase() {
   return process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000";
 }
 
-export function withUserId(headers = {}, userId) {
+export function withUserId(headers = {}, user, extras = {}) {
   const h = new Headers(headers);
+  const payload =
+    user && typeof user === "object" && !Array.isArray(user)
+      ? user
+      : { userId: user };
+  const userId =
+    payload.userId ?? payload.id ?? extras.userId ?? extras.id ?? payload.email;
   if (userId) h.set("X-User-Id", String(userId));
+  const email = payload.email ?? extras.email;
+  if (email) h.set("X-User-Email", String(email).toLowerCase());
+  const isAdmin = payload.isAdmin ?? extras.isAdmin;
+  if (isAdmin) h.set("X-User-Is-Admin", "true");
   return h;
 }
 

--- a/app/lib/session.js
+++ b/app/lib/session.js
@@ -5,6 +5,7 @@ export function getSessionBasics(session) {
     session?.user?.email ||
     null;
   const isAdmin = Boolean(session?.user?.isAdmin);
-  return { userId, isAdmin };
+  const email = session?.user?.email || null;
+  return { userId, email, isAdmin };
 }
 

--- a/app/lib/subscription-config.js
+++ b/app/lib/subscription-config.js
@@ -1,0 +1,88 @@
+const BASE_PLANS = [
+  {
+    key: "starter",
+    defaultName: "Starter",
+    defaultPrice: "$19/mo",
+    defaultAllowance: 30,
+    defaultTagline: "Launch your first AI listings",
+    defaultFeatures: (allowance) => [
+      `${allowance} AI generations each month`,
+      "Download-ready PNG exports",
+      "Community support",
+    ],
+  },
+  {
+    key: "pro",
+    defaultName: "Pro",
+    defaultPrice: "$59/mo",
+    defaultAllowance: 120,
+    defaultTagline: "Scale with faster turnarounds",
+    defaultFeatures: (allowance) => [
+      `${allowance} AI generations each month`,
+      "Priority processing queue",
+      "Email support",
+    ],
+  },
+  {
+    key: "scale",
+    defaultName: "Scale",
+    defaultPrice: "Contact us",
+    defaultAllowance: 300,
+    defaultTagline: "Custom limits for growing teams",
+    defaultFeatures: () => [
+      "Custom monthly allowance",
+      "Shared workspace seats",
+      "Dedicated success manager",
+    ],
+  },
+];
+
+function env(name) {
+  return process.env[name];
+}
+
+function parseIntEnv(value, fallback) {
+  const parsed = Number.parseInt(value ?? "", 10);
+  if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+  return fallback;
+}
+
+function parseFeatures(raw, fallback) {
+  if (typeof raw !== "string") return fallback;
+  const items = raw
+    .split("|")
+    .map((item) => item.trim())
+    .filter(Boolean);
+  return items.length > 0 ? items : fallback;
+}
+
+function resolvePlan(base) {
+  const prefix = `NEXT_PUBLIC_POLAR_PLAN_${base.key.toUpperCase()}`;
+  const id = env(`${prefix}_ID`) || env(`${prefix}_PLAN_ID`) || null;
+  const name = env(`${prefix}_NAME`) || base.defaultName;
+  const price = env(`${prefix}_PRICE`) || base.defaultPrice;
+  const tagline = env(`${prefix}_TAGLINE`) || base.defaultTagline;
+  const allowance = parseIntEnv(env(`${prefix}_ALLOWANCE`), base.defaultAllowance);
+  const features = parseFeatures(
+    env(`${prefix}_FEATURES`),
+    typeof base.defaultFeatures === "function"
+      ? base.defaultFeatures(allowance)
+      : base.defaultFeatures
+  );
+
+  return {
+    key: base.key,
+    id,
+    name,
+    price,
+    allowance,
+    tagline,
+    features,
+    isAvailable: Boolean(id),
+  };
+}
+
+export function getSubscriptionPlans() {
+  return BASE_PLANS.map(resolvePlan);
+}
+

--- a/app/lib/usage-costs.js
+++ b/app/lib/usage-costs.js
@@ -1,0 +1,41 @@
+import usageRules from "@/shared/usage-rules.json";
+
+function normalizeOperations(raw) {
+  if (!raw || typeof raw !== "object") return {};
+  const entries = Object.entries(raw);
+  const result = {};
+  for (const [key, value] of entries) {
+    if (!value || typeof value !== "object") continue;
+    const cost = Number.parseFloat(value.cost);
+    if (!Number.isFinite(cost) || cost < 0) continue;
+    result[key] = {
+      key,
+      label: typeof value.label === "string" && value.label ? value.label : key,
+      description:
+        typeof value.description === "string" && value.description
+          ? value.description
+          : undefined,
+      cost,
+    };
+  }
+  return result;
+}
+
+const RAW_PRECISION = Number.isFinite(usageRules?.precision)
+  ? Number(usageRules.precision)
+  : 0;
+export const USAGE_PRECISION = RAW_PRECISION >= 0 ? Math.floor(RAW_PRECISION) : 0;
+export const USAGE_OPERATION_MAP = normalizeOperations(usageRules?.operations);
+
+export function getUsageCosts() {
+  const map = USAGE_OPERATION_MAP;
+  const costs = {};
+  for (const key of Object.keys(map)) {
+    costs[key] = map[key].cost;
+  }
+  return costs;
+}
+
+export function getUsageOperations() {
+  return Object.values(USAGE_OPERATION_MAP);
+}

--- a/app/page.js
+++ b/app/page.js
@@ -161,7 +161,8 @@ function serializeWalkthroughSeen(value) {
 
 export default function Home() {
   const { data: session } = authClient.useSession();
-  const { userId, isAdmin } = getSessionBasics(session);
+  const sessionBasics = getSessionBasics(session);
+  const { userId, email, isAdmin } = sessionBasics;
   const fileInputRef = useRef(null);
   const cameraInputRef = useRef(null);
   const [selectedFile, setSelectedFile] = useState(null);
@@ -266,7 +267,9 @@ export default function Home() {
       setEnvDefaultsLoading(true);
       try {
         const baseUrl = getApiBase();
-        const res = await fetch(`${baseUrl}/env/defaults`, { headers: withUserId({}, userId) });
+        const res = await fetch(`${baseUrl}/env/defaults`, {
+          headers: withUserId({}, sessionBasics),
+        });
         const data = await res.json();
         if (data?.items) setEnvDefaults(data.items);
       } catch {}
@@ -454,6 +457,7 @@ export default function Home() {
     desc,
     productCondition,
     userId,
+    user: sessionBasics,
     flowMode,
     resolvePoseInstruction,
     computeEffectivePrompt,
@@ -552,7 +556,7 @@ export default function Home() {
       key,
       index: idx,
       label: randomLabel || `Image ${idx + 1}`,
-      status: poseStatus[key] || (isGenerating ? "running" : "pending"),
+      status: poseStatus[key] || (isGenerating ? "queued" : "pending"),
       error: poseErrors[key],
     };
   });

--- a/backend/config.py
+++ b/backend/config.py
@@ -35,6 +35,12 @@ REDIS_OP_TIMEOUT_SECONDS = max(0.1, _env_float("REDIS_OP_TIMEOUT_SECONDS", 0.5))
 REDIS_OPERATION_RETRIES = max(0, _env_int("REDIS_OPERATION_RETRIES", 1))
 REDIS_RETRY_BACKOFF_SECONDS = max(5.0, _env_float("REDIS_RETRY_BACKOFF_SECONDS", 60.0))
 
+_POLAR_API_BASE_RAW = os.getenv("POLAR_API_BASE", "https://api.polar.sh/v1").strip()
+POLAR_API_BASE = _POLAR_API_BASE_RAW.rstrip("/") or "https://api.polar.sh/v1"
+POLAR_OAT = os.getenv("POLAR_OAT") or os.getenv("POLAR_ACCESS_TOKEN", "")
+POLAR_ORG_ID = os.getenv("POLAR_ORG_ID", "").strip()
+POLAR_WEBHOOK_SECRET = os.getenv("POLAR_WEBHOOK_SECRET", "").strip()
+
 _env_origins = os.getenv("CORS_ALLOW_ORIGINS", "*")
 CORS_ALLOW_ORIGINS: List[str] = [o.strip() for o in _env_origins.split(",") if o.strip()]
 
@@ -51,6 +57,10 @@ __all__ = [
     "GARMENT_TYPE_TTL_SECONDS",
     "LOGGER",
     "MODEL",
+    "POLAR_API_BASE",
+    "POLAR_OAT",
+    "POLAR_ORG_ID",
+    "POLAR_WEBHOOK_SECRET",
     "REDIS_OP_TIMEOUT_SECONDS",
     "REDIS_OPERATION_RETRIES",
     "REDIS_RETRY_BACKOFF_SECONDS",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,9 +4,11 @@ pillow==10.4.0
 pillow-heif==0.18.0
 google-genai==0.3.0
 python-multipart==0.0.9
+httpx==0.27.2
 SQLAlchemy==2.0.36
 psycopg[binary]==3.2.3
 boto3==1.35.59
 redis==5.1.1
 celery[redis]==5.4.0
 flower==2.0.1
+standardwebhooks==1.0.0

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -1,11 +1,12 @@
 """Route modules for the FastAPI backend."""
 from fastapi import APIRouter
 
-from . import admin, description, edit, environment, listing, model, pose
+from . import admin, billing, description, edit, environment, listing, model, pose
 
 
 router = APIRouter()
 router.include_router(admin.router)
+router.include_router(billing.router)
 router.include_router(environment.router)
 router.include_router(model.router)
 router.include_router(pose.router)

--- a/backend/routes/billing.py
+++ b/backend/routes/billing.py
@@ -1,0 +1,251 @@
+"""Billing and subscription management endpoints."""
+from __future__ import annotations
+
+import base64
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, Header, HTTPException, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+from standardwebhooks import Webhook, WebhookVerificationError
+
+from backend.config import LOGGER, POLAR_WEBHOOK_SECRET
+from backend.db import Subscription, db_session
+from backend.services.polar import (
+    PolarAPIError,
+    PolarConfigurationError,
+    create_checkout_session,
+    create_customer_portal_session,
+    upsert_plan_from_payload,
+)
+from backend.services.usage import (
+    build_usage_identity,
+    get_usage_summary,
+    sync_usage_period,
+)
+
+router = APIRouter()
+
+
+class CheckoutRequest(BaseModel):
+    plan_id: str = Field(..., description="Polar product identifier")
+    success_url: str | None = Field(None, description="URL to redirect the user after success")
+    cancel_url: str | None = Field(None, description="URL to redirect the user if checkout is cancelled")
+    customer_email: str | None = Field(None, description="Pre-fill customer email if available")
+
+
+class PortalRequest(BaseModel):
+    return_url: str | None = Field(None, description="Optional URL to navigate to after closing the portal")
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        if value.endswith("Z"):
+            value = value[:-1] + "+00:00"
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+async def _verify_webhook(request: Request) -> dict[str, Any]:
+    secret = POLAR_WEBHOOK_SECRET.strip() if POLAR_WEBHOOK_SECRET else ""
+    if not secret:
+        LOGGER.error("Polar webhook received but secret is not configured")
+        raise HTTPException(status_code=500, detail="webhook secret not configured")
+
+    body = await request.body()
+    headers = {k.lower(): v for k, v in request.headers.items()}
+
+    candidates: list[str] = [secret]
+    if not secret.startswith("whsec_"):
+        candidates.append(base64.b64encode(secret.encode()).decode())
+    else:
+        raw = secret[len("whsec_") :]
+        candidates.append(raw)
+
+    last_error: Exception | None = None
+    for candidate in candidates:
+        try:
+            webhook = Webhook(candidate)
+            payload = webhook.verify(body, headers)
+            return payload  # type: ignore[return-value]
+        except WebhookVerificationError as exc:  # pragma: no cover - depends on secret correctness
+            last_error = exc
+            continue
+
+    LOGGER.warning("Polar webhook signature verification failed")
+    raise HTTPException(status_code=400, detail="invalid signature") from last_error
+
+
+async def _handle_subscription_event(data: dict[str, Any]) -> None:
+    subscription_id = data.get("id")
+    if not subscription_id:
+        LOGGER.warning("Subscription event missing id: %s", data)
+        return
+
+    customer = data.get("customer") or {}
+    user_id = customer.get("external_id") or (data.get("metadata") or {}).get("user_id")
+    if not user_id:
+        LOGGER.warning("Subscription event missing external user id", extra={"id": subscription_id})
+        return
+
+    plan = data.get("product") or {}
+    await upsert_plan_from_payload(plan)
+
+    plan_id = data.get("product_id") or plan.get("id")
+    prices = data.get("prices") or []
+    price_id = prices[0].get("id") if prices else None
+
+    async with db_session() as session:
+        record = await session.get(Subscription, subscription_id)
+        fields = {
+            "user_id": user_id,
+            "status": data.get("status") or "unknown",
+            "plan_id": plan_id,
+            "product_id": plan_id,
+            "price_id": price_id,
+            "cancel_at_period_end": bool(data.get("cancel_at_period_end")),
+            "current_period_start": _parse_datetime(data.get("current_period_start")),
+            "current_period_end": _parse_datetime(data.get("current_period_end")),
+            "customer_id": data.get("customer_id") or customer.get("id"),
+            "customer_external_id": user_id,
+            "raw_product_json": plan,
+            "raw_subscription_json": data,
+        }
+        if record is None:
+            record = Subscription(id=subscription_id, **fields)
+            session.add(record)
+        else:
+            for key, value in fields.items():
+                setattr(record, key, value)
+
+    try:
+        await sync_usage_period(user_id)
+    except Exception:  # pragma: no cover - defensive update
+        LOGGER.warning(
+            "Failed to sync usage period after webhook", extra={"user_id": user_id}
+        )
+
+
+@router.post("/billing/checkout")
+async def create_checkout_endpoint(
+    request: CheckoutRequest,
+    x_user_id: str | None = Header(default=None, alias="X-User-Id"),
+    x_user_email: str | None = Header(default=None, alias="X-User-Email"),
+    x_user_admin: str | None = Header(default=None, alias="X-User-Is-Admin"),
+):
+    if not x_user_id:
+        return JSONResponse({"error": "missing user id"}, status_code=400)
+    try:
+        checkout = await create_checkout_session(
+            user_id=x_user_id,
+            plan_id=request.plan_id,
+            success_url=request.success_url,
+            cancel_url=request.cancel_url,
+            customer_email=request.customer_email,
+        )
+        identity = _identity_from_headers(
+            x_user_id, email=x_user_email, is_admin=x_user_admin
+        )
+        usage = await get_usage_summary(identity)
+        return {"ok": True, "checkout": checkout, "usage": usage.to_dict()}
+    except PolarConfigurationError:
+        LOGGER.warning("Checkout attempted without Polar configuration")
+        return JSONResponse({"error": "billing not configured"}, status_code=503)
+    except PolarAPIError as exc:
+        LOGGER.exception("Failed to create Polar checkout")
+        return JSONResponse({"error": str(exc)}, status_code=502)
+
+
+@router.post("/billing/portal")
+async def create_portal_endpoint(
+    request: PortalRequest,
+    x_user_id: str | None = Header(default=None, alias="X-User-Id"),
+    x_user_email: str | None = Header(default=None, alias="X-User-Email"),
+    x_user_admin: str | None = Header(default=None, alias="X-User-Is-Admin"),
+):
+    if not x_user_id:
+        return JSONResponse({"error": "missing user id"}, status_code=400)
+    try:
+        session = await create_customer_portal_session(user_id=x_user_id)
+        identity = _identity_from_headers(
+            x_user_id, email=x_user_email, is_admin=x_user_admin
+        )
+        usage = await get_usage_summary(identity)
+        payload = {"session": session, "return_url": request.return_url} if request.return_url else session
+        return {"ok": True, "portal": payload, "usage": usage.to_dict()}
+    except PolarConfigurationError:
+        LOGGER.warning("Portal requested without Polar configuration")
+        return JSONResponse({"error": "billing not configured"}, status_code=503)
+    except PolarAPIError as exc:
+        LOGGER.exception("Failed to create Polar customer portal session")
+        return JSONResponse({"error": str(exc)}, status_code=502)
+
+
+@router.get("/billing/usage")
+async def usage_endpoint(
+    x_user_id: str | None = Header(default=None, alias="X-User-Id"),
+    x_user_email: str | None = Header(default=None, alias="X-User-Email"),
+    x_user_admin: str | None = Header(default=None, alias="X-User-Is-Admin"),
+):
+    if not x_user_id:
+        return JSONResponse({"error": "missing user id"}, status_code=400)
+    identity = _identity_from_headers(
+        x_user_id, email=x_user_email, is_admin=x_user_admin
+    )
+    summary = await get_usage_summary(identity)
+    return {"ok": True, "usage": summary.to_dict()}
+
+
+@router.get("/usage/me")
+async def usage_me_endpoint(
+    x_user_id: str | None = Header(default=None, alias="X-User-Id"),
+    x_user_email: str | None = Header(default=None, alias="X-User-Email"),
+    x_user_admin: str | None = Header(default=None, alias="X-User-Is-Admin"),
+):
+    if not x_user_id:
+        return JSONResponse({"error": "missing user id"}, status_code=400)
+    identity = _identity_from_headers(
+        x_user_id, email=x_user_email, is_admin=x_user_admin
+    )
+    summary = await get_usage_summary(identity)
+    payload = summary.to_dict()
+    payload["current_period_start"] = payload.get("period", {}).get("start")
+    payload["current_period_end"] = payload.get("period", {}).get("end")
+    return {"ok": True, "usage": payload}
+
+
+@router.post("/billing/webhook")
+async def webhook_endpoint(request: Request):
+    payload = await _verify_webhook(request)
+    event_type = payload.get("type")
+    data = payload.get("data") or {}
+
+    try:
+        if event_type and event_type.startswith("subscription."):
+            await _handle_subscription_event(data)
+        return {"ok": True}
+    except Exception:  # pragma: no cover - defensive logging
+        LOGGER.exception("Failed to process Polar webhook", extra={"event_type": event_type})
+        return JSONResponse({"error": "internal error"}, status_code=500)
+def _parse_bool_header(value: str | None) -> bool:
+    if value is None:
+        return False
+    value = value.strip().lower()
+    return value in {"1", "true", "yes", "on"}
+
+
+def _identity_from_headers(
+    user_id: str,
+    *,
+    email: str | None,
+    is_admin: str | None,
+):
+    return build_usage_identity(
+        user_id,
+        email=email,
+        is_admin_hint=_parse_bool_header(is_admin),
+    )

--- a/backend/services/admin.py
+++ b/backend/services/admin.py
@@ -1,0 +1,39 @@
+"""Helpers for determining admin privileges."""
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+
+
+@lru_cache(maxsize=1)
+def _allowed_emails() -> set[str]:
+    raw = os.getenv("ADMIN_ALLOWED_EMAILS", "")
+    return {part.strip().lower() for part in raw.split(",") if part.strip()}
+
+
+@lru_cache(maxsize=1)
+def _allowed_domain() -> str | None:
+    domain = (os.getenv("ADMIN_ALLOWED_DOMAIN") or "").strip().lower()
+    return domain or None
+
+
+@lru_cache(maxsize=1)
+def has_admin_configuration() -> bool:
+    return bool(_allowed_emails() or _allowed_domain())
+
+
+def is_admin_identifier(identifier: str | None) -> bool:
+    if not identifier:
+        return False
+    ident = identifier.strip().lower()
+    if not ident:
+        return False
+    emails = _allowed_emails()
+    domain = _allowed_domain()
+    if not emails and not domain:
+        return False
+    if ident in emails:
+        return True
+    if domain and ident.endswith("@" + domain):
+        return True
+    return False

--- a/backend/services/polar.py
+++ b/backend/services/polar.py
@@ -1,0 +1,285 @@
+"""Helpers for interacting with the Polar API."""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, Iterable
+
+import httpx
+from sqlalchemy import select
+
+from backend.config import LOGGER, POLAR_API_BASE, POLAR_OAT, POLAR_ORG_ID
+from backend.db import SubscriptionPlan, db_session
+
+
+class PolarConfigurationError(RuntimeError):
+    """Raised when Polar is not configured but an operation was attempted."""
+
+
+class PolarAPIError(RuntimeError):
+    """Raised when the Polar API returns an error."""
+
+
+@dataclass(slots=True)
+class PolarPlan:
+    """Cached representation of a subscription plan/product."""
+
+    id: str
+    name: str
+    allowance: int
+    interval: str | None
+    currency: str | None
+    default_price_id: str | None
+    metadata: Dict[str, Any]
+    is_active: bool
+
+
+_client: httpx.AsyncClient | None = None
+_client_lock = asyncio.Lock()
+_plan_cache: dict[str, PolarPlan] = {}
+_plan_cache_expiry: float = 0.0
+_plan_cache_lock = asyncio.Lock()
+_PLAN_CACHE_TTL_SECONDS = 300.0
+
+
+async def _get_client() -> httpx.AsyncClient:
+    if not POLAR_API_BASE or not POLAR_OAT:
+        raise PolarConfigurationError("Polar API base or access token not configured")
+
+    async with _client_lock:
+        global _client
+        if _client is None:
+            headers = {
+                "authorization": f"Bearer {POLAR_OAT}",
+                "accept": "application/json",
+                "user-agent": "vintedboost-backend/1.0",
+            }
+            _client = httpx.AsyncClient(
+                base_url=POLAR_API_BASE.rstrip("/"),
+                timeout=httpx.Timeout(20.0, connect=10.0),
+                headers=headers,
+            )
+        return _client
+
+
+async def close_polar_client() -> None:
+    """Close the shared HTTP client, if created."""
+
+    async with _client_lock:
+        global _client
+        if _client is not None:
+            try:
+                await _client.aclose()
+            finally:
+                _client = None
+
+
+def _extract_allowance(data: dict[str, Any] | None) -> int:
+    if not data:
+        return 0
+    raw = (
+        data.get("metadata", {}).get("allowance")
+        or data.get("metadata", {}).get("usage_allowance")
+        or data.get("metadata", {}).get("quota")
+    )
+    if raw is None and data.get("prices"):
+        for price in data.get("prices") or []:
+            raw = (
+                price.get("metadata", {}).get("allowance")
+                or price.get("metadata", {}).get("usage_allowance")
+                or price.get("metadata", {}).get("quota")
+            )
+            if raw is not None:
+                break
+    try:
+        return max(0, int(raw)) if raw is not None else 0
+    except (TypeError, ValueError):
+        return 0
+
+
+def _plan_from_product(product: dict[str, Any]) -> PolarPlan:
+    prices = product.get("prices") or []
+    default_price = prices[0] if prices else {}
+    return PolarPlan(
+        id=product.get("id", ""),
+        name=product.get("name", ""),
+        allowance=_extract_allowance(product),
+        interval=product.get("recurring_interval"),
+        currency=default_price.get("currency"),
+        default_price_id=default_price.get("id"),
+        metadata=product.get("metadata") or {},
+        is_active=not product.get("is_archived", False),
+    )
+
+
+async def _persist_plans(plans: Iterable[PolarPlan]) -> None:
+    plans = list(plans)
+    if not plans:
+        return
+
+    async with db_session() as session:
+        result = await session.execute(
+            select(SubscriptionPlan).where(SubscriptionPlan.id.in_([p.id for p in plans]))
+        )
+        existing = {plan.id: plan for plan in result.scalars()}
+        for plan in plans:
+            record = existing.get(plan.id)
+            if record:
+                record.name = plan.name
+                record.allowance = plan.allowance
+                record.interval = plan.interval
+                record.currency = plan.currency
+                record.default_price_id = plan.default_price_id
+                record.metadata_json = plan.metadata
+                record.is_active = plan.is_active
+            else:
+                session.add(
+                    SubscriptionPlan(
+                        id=plan.id,
+                        name=plan.name,
+                        allowance=plan.allowance,
+                        interval=plan.interval,
+                        currency=plan.currency,
+                        default_price_id=plan.default_price_id,
+                        metadata_json=plan.metadata,
+                        is_active=plan.is_active,
+                    )
+                )
+
+
+async def _request(method: str, path: str, *, json: Any | None = None, params: dict[str, Any] | None = None) -> Any:
+    client = await _get_client()
+    try:
+        response = await client.request(method, path, json=json, params=params)
+    except httpx.HTTPError as exc:
+        LOGGER.exception("Polar request transport error", extra={"path": path})
+        raise PolarAPIError(f"Polar request failed: {exc}") from exc
+
+    if response.status_code >= 400:
+        detail = response.text or response.reason_phrase
+        LOGGER.error(
+            "Polar API error", extra={"status": response.status_code, "path": path, "detail": detail[:256]}
+        )
+        raise PolarAPIError(f"Polar API {response.status_code}: {detail}")
+
+    if response.status_code == 204:
+        return None
+    return response.json()
+
+
+async def refresh_plan_cache(force: bool = False) -> dict[str, PolarPlan]:
+    """Fetch subscription plans from Polar and refresh cache/DB."""
+
+    now = asyncio.get_running_loop().time()
+    async with _plan_cache_lock:
+        if not force and _plan_cache and now < _plan_cache_expiry:
+            return dict(_plan_cache)
+
+    params: dict[str, Any] = {
+        "is_recurring": True,
+        "is_archived": False,
+        "limit": 50,
+    }
+    if POLAR_ORG_ID:
+        params["organization_id"] = POLAR_ORG_ID
+
+    payload = await _request("GET", "/products/", params=params)
+    items = payload.get("items", []) if isinstance(payload, dict) else []
+    plans = [_plan_from_product(item) for item in items if item.get("id")]
+
+    await _persist_plans(plans)
+
+    async with _plan_cache_lock:
+        _plan_cache.clear()
+        _plan_cache.update({plan.id: plan for plan in plans})
+        _plan_cache_expiry = asyncio.get_running_loop().time() + _PLAN_CACHE_TTL_SECONDS
+        return dict(_plan_cache)
+
+
+async def list_cached_plans() -> list[PolarPlan]:
+    """Return cached plans, refreshing if necessary."""
+
+    plans = await refresh_plan_cache(force=False)
+    return list(plans.values())
+
+
+async def get_plan(plan_id: str, *, refresh: bool = True) -> PolarPlan | None:
+    if not plan_id:
+        return None
+    async with _plan_cache_lock:
+        plan = _plan_cache.get(plan_id)
+    if plan and not refresh:
+        return plan
+
+    if refresh or plan is None:
+        plans = await refresh_plan_cache(force=plan is None)
+        plan = plans.get(plan_id)
+
+    if plan is None:
+        # Last attempt: try loading from DB without hitting the API again.
+        async with db_session() as session:
+            record = await session.get(SubscriptionPlan, plan_id)
+            if record:
+                plan = PolarPlan(
+                    id=record.id,
+                    name=record.name,
+                    allowance=record.allowance,
+                    interval=record.interval,
+                    currency=record.currency,
+                    default_price_id=record.default_price_id,
+                    metadata=record.metadata_json or {},
+                    is_active=record.is_active,
+                )
+                async with _plan_cache_lock:
+                    _plan_cache[plan.id] = plan
+    return plan
+
+
+async def upsert_plan_from_payload(product: dict[str, Any] | None) -> PolarPlan | None:
+    """Update plan cache/DB using a product payload embedded in a webhook."""
+
+    if not product or not product.get("id"):
+        return None
+
+    plan = _plan_from_product(product)
+    await _persist_plans([plan])
+    async with _plan_cache_lock:
+        _plan_cache[plan.id] = plan
+        return plan
+
+
+async def create_checkout_session(
+    *,
+    user_id: str,
+    plan_id: str,
+    success_url: str | None = None,
+    cancel_url: str | None = None,
+    customer_email: str | None = None,
+) -> dict[str, Any]:
+    """Create a Polar checkout session for the given plan."""
+
+    payload: dict[str, Any] = {
+        "products": [plan_id],
+        "external_customer_id": user_id,
+        "metadata": {"user_id": user_id},
+        "customer_metadata": {"user_id": user_id},
+    }
+    if success_url:
+        payload["success_url"] = success_url
+    if cancel_url:
+        payload["cancel_url"] = cancel_url
+    if customer_email:
+        payload["customer_email"] = customer_email
+
+    data = await _request("POST", "/checkouts/", json=payload)
+    if isinstance(data, dict):
+        return data
+    return {"id": None, "url": None}
+
+
+async def create_customer_portal_session(*, user_id: str) -> dict[str, Any]:
+    """Create a Polar customer session using the external user identifier."""
+
+    payload = {"external_customer_id": user_id}
+    return await _request("POST", "/customer-sessions/", json=payload)

--- a/backend/services/usage.py
+++ b/backend/services/usage.py
@@ -1,0 +1,382 @@
+"""Subscription usage helpers and quota enforcement."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Iterable
+
+from sqlalchemy import Select, select
+
+from backend.db import Subscription, SubscriptionPlan, UsageCounter, db_session
+from backend.services.admin import has_admin_configuration, is_admin_identifier
+from backend.services.polar import PolarPlan, get_plan
+from backend.services.usage_rules import (
+    USAGE_PRECISION,
+    amount_to_units,
+    get_operation_costs,
+    units_to_amount,
+)
+
+_ACTIVE_STATUSES = {"active", "trialing", "past_due"}
+
+
+def _now_utc() -> datetime:
+    return datetime.utcnow()
+
+
+@dataclass(slots=True)
+class UsageIdentity:
+    """Identity data used to evaluate quota and admin overrides."""
+
+    user_id: str
+    email: str | None = None
+    is_admin_hint: bool = False
+
+    @property
+    def is_admin(self) -> bool:
+        if self.is_admin_hint:
+            return True
+        if is_admin_identifier(self.email):
+            return True
+        if has_admin_configuration():
+            return is_admin_identifier(self.user_id)
+        return False
+
+
+@dataclass(slots=True)
+class UsageSummary:
+    """Represents a user's usage status for the current billing period."""
+
+    user_id: str
+    plan_id: str | None
+    plan_name: str | None
+    plan_interval: str | None
+    currency: str | None
+    status: str | None
+    cancel_at_period_end: bool
+    allowance: float | None
+    used: float
+    remaining: float | None
+    period_start: datetime | None
+    period_end: datetime | None
+    allowance_units: int
+    used_units: int
+    remaining_units: int
+    precision: int
+    is_unlimited: bool
+    costs: dict[str, float]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "plan": {
+                "id": self.plan_id,
+                "name": self.plan_name,
+                "interval": self.plan_interval,
+                "currency": self.currency,
+                "status": self.status,
+                "cancel_at_period_end": self.cancel_at_period_end,
+            },
+            "allowance": self.allowance,
+            "used": self.used,
+            "remaining": self.remaining,
+            "period": {
+                "start": self.period_start.isoformat() if self.period_start else None,
+                "end": self.period_end.isoformat() if self.period_end else None,
+            },
+            "precision": self.precision,
+            "is_unlimited": self.is_unlimited,
+            "costs": dict(self.costs),
+        }
+
+    def apply_plan(self, plan: PolarPlan) -> None:
+        if plan.id:
+            self.plan_id = plan.id
+        if plan.name:
+            self.plan_name = plan.name
+        if plan.interval:
+            self.plan_interval = plan.interval
+        if plan.currency:
+            self.currency = plan.currency
+        if self.status in _ACTIVE_STATUSES and not self.is_unlimited:
+            allowance_units = amount_to_units(plan.allowance)
+            self.allowance_units = allowance_units
+            self.allowance = units_to_amount(allowance_units)
+            self.remaining_units = max(allowance_units - self.used_units, 0)
+            self.remaining = units_to_amount(self.remaining_units)
+
+
+class QuotaError(RuntimeError):
+    """Raised when a user attempts to operate without quota."""
+
+    def __init__(self, summary: UsageSummary) -> None:
+        super().__init__("quota exceeded")
+        self.summary = summary
+
+
+def build_usage_identity(
+    user_id: str,
+    *,
+    email: str | None = None,
+    is_admin_hint: bool | None = None,
+) -> UsageIdentity:
+    return UsageIdentity(
+        user_id=user_id,
+        email=email,
+        is_admin_hint=bool(is_admin_hint),
+    )
+
+
+def _coerce_identity(
+    identity: UsageIdentity | str,
+    *,
+    email: str | None = None,
+    is_admin: bool | None = None,
+) -> UsageIdentity:
+    if isinstance(identity, UsageIdentity):
+        return UsageIdentity(
+            user_id=identity.user_id,
+            email=identity.email if identity.email is not None else email,
+            is_admin_hint=identity.is_admin_hint or bool(is_admin),
+        )
+    return UsageIdentity(user_id=identity, email=email, is_admin_hint=bool(is_admin))
+
+
+async def _select_subscription(session, user_id: str) -> Subscription | None:
+    stmt: Select[Subscription] = (
+        select(Subscription)
+        .where(Subscription.user_id == user_id)
+        .order_by(Subscription.current_period_end.desc().nullslast(), Subscription.created_at.desc())
+        .limit(1)
+    )
+    result = await session.execute(stmt)
+    return result.scalars().first()
+
+
+async def _ensure_usage_record(
+    session,
+    user_id: str,
+    subscription: Subscription | None,
+) -> UsageCounter | None:
+    if not subscription:
+        return None
+    period_start = subscription.current_period_start
+    if not period_start:
+        return None
+    period_end = subscription.current_period_end
+
+    stmt: Select[UsageCounter] = select(UsageCounter).where(
+        UsageCounter.user_id == user_id,
+        UsageCounter.period_start == period_start,
+    )
+    result = await session.execute(stmt)
+    usage = result.scalars().first()
+
+    if usage is None:
+        usage = UsageCounter(
+            user_id=user_id,
+            period_start=period_start,
+            period_end=period_end,
+            used=0,
+        )
+        session.add(usage)
+        await session.flush()
+        return usage
+
+    reset_needed = usage.period_start != period_start
+    if reset_needed:
+        usage.period_start = period_start
+        usage.used = 0
+    if usage.period_end != period_end:
+        usage.period_end = period_end
+    if reset_needed:
+        usage.updated_at = _now_utc()
+    return usage
+
+
+async def _load_usage_state(
+    session,
+    identity: UsageIdentity,
+) -> tuple[Subscription | None, SubscriptionPlan | None, UsageCounter | None]:
+    subscription = await _select_subscription(session, identity.user_id)
+    plan: SubscriptionPlan | None = None
+    if subscription and subscription.plan_id:
+        plan = await session.get(SubscriptionPlan, subscription.plan_id)
+    usage = await _ensure_usage_record(session, identity.user_id, subscription)
+    return subscription, plan, usage
+
+
+def _is_subscription_active(subscription: Subscription | None) -> bool:
+    if not subscription:
+        return False
+    status = (subscription.status or "").lower()
+    return status in _ACTIVE_STATUSES
+
+
+def _build_summary(
+    identity: UsageIdentity,
+    subscription: Subscription | None,
+    plan: SubscriptionPlan | None,
+    usage: UsageCounter | None,
+) -> UsageSummary:
+    plan_id = subscription.plan_id if subscription else None
+    plan_name = plan.name if plan else None
+    plan_interval = plan.interval if plan else None
+    currency = plan.currency if plan else None
+    status = subscription.status if subscription else None
+    cancel_at_period_end = bool(subscription.cancel_at_period_end) if subscription else False
+
+    allowance_units = 0
+    if plan and _is_subscription_active(subscription):
+        allowance_units = amount_to_units(plan.allowance)
+    used_units = usage.used if usage else 0
+    remaining_units = max(allowance_units - used_units, 0)
+
+    allowance = units_to_amount(allowance_units) if allowance_units else 0.0
+    used = units_to_amount(used_units)
+    remaining = units_to_amount(remaining_units)
+    period_start = subscription.current_period_start if subscription else None
+    period_end = subscription.current_period_end if subscription else None
+
+    summary = UsageSummary(
+        user_id=identity.user_id,
+        plan_id=plan_id,
+        plan_name=plan_name,
+        plan_interval=plan_interval,
+        currency=currency,
+        status=status,
+        cancel_at_period_end=cancel_at_period_end,
+        allowance=allowance,
+        used=used,
+        remaining=remaining,
+        period_start=period_start,
+        period_end=period_end,
+        allowance_units=allowance_units,
+        used_units=used_units,
+        remaining_units=remaining_units,
+        precision=USAGE_PRECISION,
+        is_unlimited=identity.is_admin,
+        costs=get_operation_costs(),
+    )
+
+    if summary.is_unlimited:
+        summary.remaining = None
+        summary.remaining_units = 0
+
+    return summary
+
+
+async def get_usage_summary(
+    identity: UsageIdentity | str,
+    *,
+    email: str | None = None,
+    is_admin: bool | None = None,
+) -> UsageSummary:
+    ident = _coerce_identity(identity, email=email, is_admin=is_admin)
+
+    async with db_session() as session:
+        subscription, plan, usage = await _load_usage_state(session, ident)
+
+    summary = _build_summary(ident, subscription, plan, usage)
+    if subscription and subscription.plan_id and plan is None:
+        polar_plan = await get_plan(subscription.plan_id, refresh=False)
+        if polar_plan:
+            summary.apply_plan(polar_plan)
+    return summary
+
+
+async def ensure_can_consume(
+    identity: UsageIdentity | str,
+    amount: float = 1.0,
+    *,
+    email: str | None = None,
+    is_admin: bool | None = None,
+) -> UsageSummary:
+    summary = await get_usage_summary(identity, email=email, is_admin=is_admin)
+    ident = _coerce_identity(identity, email=email, is_admin=is_admin)
+    if ident.is_admin:
+        return summary
+    amount_units = amount_to_units(amount)
+    if amount_units > 0 and summary.remaining_units < amount_units:
+        raise QuotaError(summary)
+    return summary
+
+
+async def _consume_with_session(
+    session,
+    identity: UsageIdentity,
+    amount: float,
+) -> UsageSummary:
+    if identity.is_admin or amount <= 0:
+        subscription, plan, usage = await _load_usage_state(session, identity)
+        return _build_summary(identity, subscription, plan, usage)
+
+    amount_units = amount_to_units(amount)
+    if amount_units <= 0:
+        subscription, plan, usage = await _load_usage_state(session, identity)
+        return _build_summary(identity, subscription, plan, usage)
+
+    subscription, plan, usage = await _load_usage_state(session, identity)
+    if not subscription:
+        summary = _build_summary(identity, None, None, None)
+        raise QuotaError(summary)
+
+    summary = _build_summary(identity, subscription, plan, usage)
+    if summary.remaining_units < amount_units:
+        raise QuotaError(summary)
+    if usage is None:
+        raise QuotaError(summary)
+
+    usage.used = usage.used + amount_units
+    usage.updated_at = _now_utc()
+    summary = _build_summary(identity, subscription, plan, usage)
+    return summary
+
+
+async def consume_quota(
+    identity: UsageIdentity | str,
+    amount: float = 1.0,
+    *,
+    email: str | None = None,
+    is_admin: bool | None = None,
+) -> UsageSummary:
+    ident = _coerce_identity(identity, email=email, is_admin=is_admin)
+
+    async with db_session() as session:
+        summary = await _consume_with_session(session, ident, amount)
+
+    if summary.plan_id and summary.plan_name is None:
+        polar_plan = await get_plan(summary.plan_id, refresh=False)
+        if polar_plan:
+            summary.apply_plan(polar_plan)
+    return summary
+
+
+async def consume_quota_with_session(
+    session,
+    identity: UsageIdentity | str,
+    amount: float,
+    *,
+    email: str | None = None,
+    is_admin: bool | None = None,
+) -> UsageSummary:
+    ident = _coerce_identity(identity, email=email, is_admin=is_admin)
+    summary = await _consume_with_session(session, ident, amount)
+    if summary.plan_id and summary.plan_name is None:
+        polar_plan = await get_plan(summary.plan_id, refresh=False)
+        if polar_plan:
+            summary.apply_plan(polar_plan)
+    return summary
+
+
+async def sync_usage_period(user_id: str) -> None:
+    identity = UsageIdentity(user_id=user_id)
+    async with db_session() as session:
+        await _load_usage_state(session, identity)
+
+
+async def apply_usage_refresh(
+    session,
+    identities: Iterable[UsageIdentity],
+) -> None:
+    for identity in identities:
+        await _load_usage_state(session, identity)

--- a/backend/services/usage_rules.py
+++ b/backend/services/usage_rules.py
@@ -1,0 +1,116 @@
+"""Shared helpers for usage costs loaded from the repo-level config."""
+from __future__ import annotations
+
+import json
+from decimal import Decimal, ROUND_HALF_UP
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict
+
+_DEFAULT_COST = Decimal("1")
+
+
+def _load_rules() -> dict[str, Any]:
+    path = Path(__file__).resolve().parents[2] / "shared" / "usage-rules.json"
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+            if isinstance(data, dict):
+                return data
+    except FileNotFoundError:
+        return {"precision": 0, "operations": {}}
+    except json.JSONDecodeError:
+        return {"precision": 0, "operations": {}}
+    return {"precision": 0, "operations": {}}
+
+
+@lru_cache(maxsize=1)
+def _get_rules() -> dict[str, Any]:
+    return _load_rules()
+
+
+@lru_cache(maxsize=1)
+def get_usage_precision() -> int:
+    raw = _get_rules().get("precision")
+    try:
+        value = int(raw)
+        return value if value >= 0 else 0
+    except (TypeError, ValueError):
+        return 0
+
+
+@lru_cache(maxsize=1)
+def _get_scale() -> Decimal:
+    precision = get_usage_precision()
+    if precision <= 0:
+        return Decimal("1")
+    return Decimal(10) ** precision
+
+
+@lru_cache(maxsize=1)
+def get_operation_metadata() -> Dict[str, dict[str, Any]]:
+    raw = _get_rules().get("operations")
+    if not isinstance(raw, dict):
+        return {}
+    metadata: Dict[str, dict[str, Any]] = {}
+    for key, value in raw.items():
+        if not isinstance(value, dict):
+            continue
+        cost_raw = value.get("cost", 0)
+        try:
+            cost = Decimal(str(cost_raw))
+        except (TypeError, ValueError, ArithmeticError):
+            continue
+        if cost < 0:
+            continue
+        metadata[key] = {
+            "label": value.get("label"),
+            "description": value.get("description"),
+            "cost": cost,
+        }
+    return metadata
+
+
+@lru_cache(maxsize=1)
+def get_operation_costs() -> Dict[str, float]:
+    metadata = get_operation_metadata()
+    return {key: float(value["cost"]) for key, value in metadata.items()}
+
+
+def get_operation_cost(operation: str, default: Decimal | float | int = _DEFAULT_COST) -> float:
+    metadata = get_operation_metadata()
+    if operation in metadata:
+        return float(metadata[operation]["cost"])
+    try:
+        return float(Decimal(str(default)))
+    except (TypeError, ValueError, ArithmeticError):
+        return float(_DEFAULT_COST)
+
+
+def amount_to_units(amount: Decimal | float | int) -> int:
+    try:
+        dec = Decimal(str(amount))
+    except (TypeError, ValueError, ArithmeticError):
+        dec = Decimal(0)
+    if dec <= 0:
+        return 0
+    scale = _get_scale()
+    scaled = dec * scale
+    return int(scaled.to_integral_value(rounding=ROUND_HALF_UP))
+
+
+def units_to_amount(units: int) -> float:
+    try:
+        raw = int(units)
+    except (TypeError, ValueError):
+        raw = 0
+    scale = _get_scale()
+    if scale == 0:
+        return float(raw)
+    dec = Decimal(raw) / scale
+    return float(dec)
+
+
+USAGE_PRECISION = get_usage_precision()
+USAGE_SCALE = int(_get_scale())
+DEFAULT_OPERATION_COST = float(_DEFAULT_COST)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@floating-ui/react": "^0.27.2",
+        "@polar-sh/checkout": "^0.1.12",
         "better-auth": "^1.3.9",
         "browser-image-compression": "^2.0.2",
         "clsx": "^2.1.1",
@@ -1040,6 +1041,1222 @@
         "tslib": "^2.8.1"
       }
     },
+    "node_modules/@polar-sh/checkout": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@polar-sh/checkout/-/checkout-0.1.12.tgz",
+      "integrity": "sha512-CmNdrZKOnr22Z2Cj0yeD0VfxeHW4eJufHjdufORBZwjoSnr9/xkUm+mdGIBlTGZRfAC2AekQ/ie8aqx9PVWfLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polar-sh/sdk": "^0.34.9",
+        "@polar-sh/ui": "^0.1.1",
+        "event-source-plus": "^0.1.11",
+        "eventemitter3": "^5.0.1",
+        "markdown-to-jsx": "^7.7.12",
+        "react-hook-form": "^7.60.0"
+      },
+      "peerDependencies": {
+        "@stripe/react-stripe-js": "^3.6.0",
+        "@stripe/stripe-js": "^7.1.0",
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@polar-sh/checkout/node_modules/@polar-sh/ui": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@polar-sh/ui/-/ui-0.1.1.tgz",
+      "integrity": "sha512-DZfYUTMxqXNPmYr2l9dhaY+zmFNANlKe7bzjV5mgUrBFo4SjxytELErOjM2g5aTmuDm7kPuGB2YJnuqnvhqRTw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@radix-ui/react-accordion": "^1.1.2",
+        "@radix-ui/react-alert-dialog": "^1.1.2",
+        "@radix-ui/react-checkbox": "^1.0.4",
+        "@radix-ui/react-dialog": "^1.1.2",
+        "@radix-ui/react-dropdown-menu": "^2.1.2",
+        "@radix-ui/react-label": "^2.0.2",
+        "@radix-ui/react-popover": "^1.0.7",
+        "@radix-ui/react-radio-group": "^1.1.3",
+        "@radix-ui/react-select": "^2.1.4",
+        "@radix-ui/react-separator": "^1.0.3",
+        "@radix-ui/react-slot": "^1.1.0",
+        "@radix-ui/react-switch": "^1.0.3",
+        "@radix-ui/react-tabs": "^1.0.4",
+        "@radix-ui/react-toast": "^1.2.2",
+        "@radix-ui/react-toggle": "^1.1.0",
+        "@radix-ui/react-toggle-group": "^1.1.0",
+        "@radix-ui/react-tooltip": "^1.0.7",
+        "@tanstack/react-table": "^8.20.5",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "cmdk": "^1.0.0",
+        "countries-list": "^3.1.1",
+        "date-fns": "^3.6.0",
+        "input-otp": "^1.4.1",
+        "lucide-react": "^0.461.0",
+        "react-day-picker": "^8.10.1",
+        "react-hook-form": "^7.54.2",
+        "react-timeago": "^7.2.0",
+        "tailwind-merge": "^2.5.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      }
+    },
+    "node_modules/@polar-sh/checkout/node_modules/@polar-sh/ui/node_modules/react-day-picker": {
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.10.1.tgz",
+      "integrity": "sha512-TMx7fNbhLk15eqcMt+7Z7S2KF7mfTId/XJDjKE8f+IUcFn0l08/kI4FiYTL/0yuOLmEcbR4Fwe3GJf/NiiMnPA==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
+      },
+      "peerDependencies": {
+        "date-fns": "^2.28.0 || ^3.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@polar-sh/checkout/node_modules/@polar-sh/ui/node_modules/react-timeago": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/react-timeago/-/react-timeago-7.2.0.tgz",
+      "integrity": "sha512-2KsBEEs+qRhKx/kekUVNSTIpop3Jwd7SRBm0R4Eiq3mPeswRGSsftY9FpKsE/lXLdURyQFiHeHFrIUxLYskG5g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@polar-sh/checkout/node_modules/lucide-react": {
+      "version": "0.461.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.461.0.tgz",
+      "integrity": "sha512-Scpw3D/dV1bgVRC5Kh774RCm99z0iZpPv75M6kg7QL1lLvkQ1rmI1Sjjic1aGp1ULBwd7FokV6ry0g+d6pMB+w==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@polar-sh/checkout/node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/@polar-sh/checkout/node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/@polar-sh/sdk": {
+      "version": "0.34.17",
+      "resolved": "https://registry.npmjs.org/@polar-sh/sdk/-/sdk-0.34.17.tgz",
+      "integrity": "sha512-+eJAAyyP4CAtMy9Hd6gaNXErjaH3KuTXJFv72kqlCCvv7SweBlM4U2+zpeYAZvd/YMRZq/c447f0a0DD2e7UEA==",
+      "dependencies": {
+        "standardwebhooks": "^1.0.0",
+        "zod": "^3.25.76"
+      },
+      "bin": {
+        "mcp": "bin/mcp-server.js"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": ">=1.5.0 <1.10.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@polar-sh/sdk/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-accordion": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.12.tgz",
+      "integrity": "sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collapsible": "1.1.12",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
+      "integrity": "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+      "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
+      "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
+      "integrity": "sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
+      "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
+      "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+      "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toast": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.15.tgz",
+      "integrity": "sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
+      "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.11.tgz",
+      "integrity": "sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-toggle": "1.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1072,6 +2289,37 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@stripe/react-stripe-js": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-3.10.0.tgz",
+      "integrity": "sha512-UPqHZwMwDzGSax0ZI7XlxR3tZSpgIiZdk3CiwjbTK978phwR/fFXeAXQcN/h8wTAjR4ZIAzdlI9DbOqJhuJdeg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "@stripe/stripe-js": ">=1.44.1 <8.0.0",
+        "react": ">=16.8.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-7.9.0.tgz",
+      "integrity": "sha512-ggs5k+/0FUJcIgNY08aZTqpBTtbExkJMYMLSMwyucrhtWexVOEY1KJmhBsxf+E/Q15f5rbwBpj+t0t2AW2oCsQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.16"
       }
     },
     "node_modules/@swc/helpers": {
@@ -1341,6 +2589,39 @@
         "@tailwindcss/oxide": "4.1.13",
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.13"
+      }
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -1961,6 +3242,18 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/aria-query": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
@@ -2365,6 +3658,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -2390,6 +3695,22 @@
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/color": {
@@ -2478,6 +3799,12 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/countries-list": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/countries-list/-/countries-list-3.1.1.tgz",
+      "integrity": "sha512-nPklKJ5qtmY5MdBKw1NiBAoyx5Sa7p2yPpljZyQ7gyCN1m+eMFs9I6CT37Mxt8zvR5L3VzD3DJBE4WQzX3WF4A==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2554,6 +3881,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -2616,6 +3953,12 @@
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
       "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="
     },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "license": "MIT"
+    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -2624,6 +3967,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -3264,6 +4613,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-source-plus": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/event-source-plus/-/event-source-plus-0.1.12.tgz",
+      "integrity": "sha512-98wOULBKdZV9BnI2OY0wCb4VCoQmyRyESDtKPYR4l9D8hEXbfLdk0ue6va1zlYW1wqhcJHm2w9kJtUtsl9ZB9A==",
+      "license": "MIT",
+      "dependencies": {
+        "ofetch": "^1.4.1"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3309,6 +4673,12 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -3488,6 +4858,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-proto": {
@@ -3728,6 +5107,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/input-otp": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/input-otp/-/input-otp-1.4.2.tgz",
+      "integrity": "sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/internal-slot": {
@@ -4183,8 +5572,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -4544,7 +5932,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -4567,6 +5954,18 @@
       "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/markdown-to-jsx": {
+      "version": "7.7.13",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.7.13.tgz",
+      "integrity": "sha512-DiueEq2bttFcSxUs85GJcQVrOr0+VVsPfj9AEUPqmExJ3f8P/iQNvZHltV4tm1XVhu1kl0vWBZWT3l99izRMaA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0"
       }
     },
     "node_modules/math-intrinsics": {
@@ -4806,11 +6205,16 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4919,6 +6323,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ofetch": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.4.1.tgz",
+      "integrity": "sha512-QZj2DfGplQAr2oj9KzceK9Hwz6Whxazmn85yYeVuS3u9XTMOGMRx0kO95MQ+vLsj/S/NwBDMMLU5hpxvI6Tklw==",
+      "license": "MIT",
+      "dependencies": {
+        "destr": "^2.0.3",
+        "node-fetch-native": "^1.6.4",
+        "ufo": "^1.5.4"
       }
     },
     "node_modules/optionator": {
@@ -5204,7 +6619,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -5275,6 +6689,22 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.63.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.63.0.tgz",
+      "integrity": "sha512-ZwueDMvUeucovM2VjkCf7zIHcs1aAlDimZu2Hvel5C5907gUzMpm4xCrQXtRzCvsBqFjonB4m3x4LzCFI1ZKWA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-hot-toast": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
@@ -5294,8 +6724,76 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
+      "integrity": "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -5731,6 +7229,16 @@
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -5954,6 +7462,16 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
       "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
+    },
+    "node_modules/tailwind-merge": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.0.tgz",
+      "integrity": "sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
     },
     "node_modules/tailwindcss": {
       "version": "4.1.13",
@@ -6186,6 +7704,12 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/ufo": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "license": "MIT"
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -6250,6 +7774,49 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/uzip": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "better-auth": "^1.3.9",
+    "@polar-sh/checkout": "^0.1.12",
     "browser-image-compression": "^2.0.2",
     "clsx": "^2.1.1",
     "heic2any": "^0.0.4",

--- a/shared/usage-rules.json
+++ b/shared/usage-rules.json
@@ -1,0 +1,25 @@
+{
+  "precision": 1,
+  "operations": {
+    "listing.create": {
+      "label": "Create listing",
+      "description": "Upload a new garment and start a listing workflow.",
+      "cost": 1
+    },
+    "generation.pose": {
+      "label": "Generate listing pose",
+      "description": "Create an AI try-on image or listing variation.",
+      "cost": 1
+    },
+    "studio.environment": {
+      "label": "Generate studio environment",
+      "description": "Produce a new backdrop or mirror environment.",
+      "cost": 0.5
+    },
+    "studio.model": {
+      "label": "Generate studio model",
+      "description": "Create or refresh an in-house model reference.",
+      "cost": 1
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add shared usage rules consumed by both Next.js and FastAPI along with admin helpers so flagged users bypass quota checks
- expand billing routes with a /usage/me payload and ensure webhook/checkout handlers refresh usage while returning plan state
- update frontend subscription context, nav, studio tools, and API proxies to pass email/admin hints, respect unlimited plans, and expose per-operation costs

## Testing
- npm run lint
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68ce8222432c833389af14f22a347733